### PR TITLE
feat: 메일 인증, OAuth2 구글 로그인 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-mail</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>dev.langchain4j</groupId>
       <artifactId>langchain4j-google-ai-gemini-spring-boot-starter</artifactId>
       <version>1.0.0-beta3</version>

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-oauth2-client</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>dev.langchain4j</groupId>
       <artifactId>langchain4j-google-ai-gemini-spring-boot-starter</artifactId>
       <version>1.0.0-beta3</version>

--- a/src/main/java/com/grepp/funfun/app/controller/api/auth/AuthApiController.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/auth/AuthApiController.java
@@ -34,7 +34,7 @@ public class AuthApiController {
         TokenDto tokenDto = authService.signin(loginRequest);
         
         ResponseCookie accessToken = TokenCookieFactory.create(AuthToken.ACCESS_TOKEN.name(),
-            tokenDto.getAccessToken(), tokenDto.getExpiresIn());
+            tokenDto.getAccessToken(), tokenDto.getRefreshExpiresIn());
         ResponseCookie refreshToken = TokenCookieFactory.create(AuthToken.REFRESH_TOKEN.name(),
             tokenDto.getRefreshToken(), tokenDto.getRefreshExpiresIn());
         

--- a/src/main/java/com/grepp/funfun/app/controller/api/user/UserApiController.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/user/UserApiController.java
@@ -2,6 +2,7 @@ package com.grepp.funfun.app.controller.api.user;
 
 import com.grepp.funfun.app.controller.api.auth.payload.TokenResponse;
 import com.grepp.funfun.app.controller.api.user.payload.SignupRequest;
+import com.grepp.funfun.app.controller.api.user.payload.VerifyCodeRequest;
 import com.grepp.funfun.app.model.auth.code.AuthToken;
 import com.grepp.funfun.app.model.auth.dto.TokenDto;
 import com.grepp.funfun.app.model.user.dto.UserDTO;
@@ -17,6 +18,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -71,7 +73,7 @@ public class UserApiController {
         return ResponseEntity.noContent().build();
     }
 
-    @PostMapping("/verify")
+    @PostMapping("/verify/signup")
     public ResponseEntity<ApiResponse<TokenResponse>> verifySignup(@RequestParam("code") String code,  HttpServletResponse response) {
         TokenDto tokenDto = userService.verifySignupCode(code);
 
@@ -90,9 +92,24 @@ public class UserApiController {
             .build()));
     }
 
-    @PostMapping("/verify/{email}")
+    @PostMapping("/send/signup/{email}")
     public ResponseEntity<ApiResponse<String>> resendVerificationSignupMail(@PathVariable("email") String email) {
         userService.resendVerificationSignupEmail(email);
         return ResponseEntity.ok(ApiResponse.success(email));
     }
+
+    @PostMapping("/send/code")
+    public ResponseEntity<ApiResponse<String>> sendCode(Authentication authentication) {
+        String email = authentication.getName();
+        userService.sendCode(email);
+        return ResponseEntity.ok(ApiResponse.success("인증 메일을 발송했습니다."));
+    }
+
+    @PostMapping("/verify/code")
+    public ResponseEntity<ApiResponse<String>> verifyCode(@RequestBody @Valid VerifyCodeRequest request, Authentication authentication) {
+        String email = authentication.getName();
+        userService.verifyCode(email, request.getCode());
+        return ResponseEntity.ok(ApiResponse.success("인증이 완료되었습니다."));
+    }
+
 }

--- a/src/main/java/com/grepp/funfun/app/controller/api/user/UserApiController.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/user/UserApiController.java
@@ -1,6 +1,7 @@
 package com.grepp.funfun.app.controller.api.user;
 
 import com.grepp.funfun.app.controller.api.auth.payload.TokenResponse;
+import com.grepp.funfun.app.controller.api.user.payload.ChangePasswordRequest;
 import com.grepp.funfun.app.controller.api.user.payload.SignupRequest;
 import com.grepp.funfun.app.controller.api.user.payload.VerifyCodeRequest;
 import com.grepp.funfun.app.model.auth.code.AuthToken;
@@ -14,13 +15,13 @@ import com.grepp.funfun.util.ReferencedWarning;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import java.util.List;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -112,4 +113,12 @@ public class UserApiController {
         return ResponseEntity.ok(ApiResponse.success("인증이 완료되었습니다."));
     }
 
+    @PatchMapping("/change/password")
+    public ResponseEntity<ApiResponse<String>> changePassword(@RequestBody @Valid
+        ChangePasswordRequest request, Authentication authentication) {
+        String email = authentication.getName();
+        userService.changePassword(email, request.getPassword());
+
+        return ResponseEntity.ok(ApiResponse.success("비밀번호 변경이 완료되었습니다."));
+    }
 }

--- a/src/main/java/com/grepp/funfun/app/controller/api/user/UserApiController.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/user/UserApiController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 
@@ -64,4 +65,15 @@ public class UserApiController {
         return ResponseEntity.noContent().build();
     }
 
+    @PostMapping("/verify")
+    public ResponseEntity<ApiResponse<String>> verifySignup(@RequestParam("code") String code) {
+        String email = userService.verifySignupCode(code);
+        return ResponseEntity.ok(ApiResponse.success(email));
+    }
+
+    @PostMapping("/verify/{email}")
+    public ResponseEntity<ApiResponse<String>> resendVerificationSignupMail(@PathVariable("email") String email) {
+        userService.resendVerificationSignupEmail(email);
+        return ResponseEntity.ok(ApiResponse.success(email));
+    }
 }

--- a/src/main/java/com/grepp/funfun/app/controller/api/user/UserApiController.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/user/UserApiController.java
@@ -2,6 +2,7 @@ package com.grepp.funfun.app.controller.api.user;
 
 import com.grepp.funfun.app.controller.api.auth.payload.TokenResponse;
 import com.grepp.funfun.app.controller.api.user.payload.ChangePasswordRequest;
+import com.grepp.funfun.app.controller.api.user.payload.OAuth2SignupRequest;
 import com.grepp.funfun.app.controller.api.user.payload.SignupRequest;
 import com.grepp.funfun.app.controller.api.user.payload.VerifyCodeRequest;
 import com.grepp.funfun.app.model.auth.code.AuthToken;
@@ -55,6 +56,13 @@ public class UserApiController {
     public ResponseEntity<ApiResponse<String>> createUser(@RequestBody @Valid SignupRequest request) {
         String createdEmail = userService.create(request);
         return ResponseEntity.ok(ApiResponse.success(createdEmail));
+    }
+
+    @PatchMapping("/oauth2")
+    public ResponseEntity<ApiResponse<String>> updateOAuth2User(@RequestBody @Valid OAuth2SignupRequest request, Authentication authentication) {
+        String email = authentication.getName();
+        userService.updateOAuth2User(email, request);
+        return ResponseEntity.ok(ApiResponse.success(email));
     }
 
     @PutMapping("/{email}")

--- a/src/main/java/com/grepp/funfun/app/controller/api/user/payload/ChangePasswordRequest.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/user/payload/ChangePasswordRequest.java
@@ -1,0 +1,23 @@
+package com.grepp.funfun.app.controller.api.user.payload;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Data;
+
+@Data
+public class ChangePasswordRequest {
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Pattern(
+        regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/?]).{8,20}$",
+        message = "비밀번호는 최소 8자리 이상에서 최대 20자리 이하의 영문자, 숫자, 특수문자 조합으로 이루어져야 합니다."
+    )
+    private String password;
+
+    private String confirmPassword;
+
+    @AssertTrue(message = "비밀번호가 서로 일치하지 않습니다.")
+    public boolean isConfirmPassword() {
+        return password.equals(confirmPassword);
+    }
+}

--- a/src/main/java/com/grepp/funfun/app/controller/api/user/payload/OAuth2SignupRequest.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/user/payload/OAuth2SignupRequest.java
@@ -1,0 +1,42 @@
+package com.grepp.funfun.app.controller.api.user.payload;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.grepp.funfun.app.model.auth.code.Role;
+import com.grepp.funfun.app.model.user.code.Gender;
+import com.grepp.funfun.app.model.user.entity.User;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class OAuth2SignupRequest {
+
+    @NotBlank(message = "닉네임은 필수입니다.")
+    private String nickname;
+
+    @NotBlank(message = "주소는 필수입니다.")
+    private String address;
+
+    @NotBlank(message = "전화번호는 필수입니다.")
+    private String tel;
+
+    @NotNull(message = "나이는 필수입니다.")
+    private int age;
+
+    @NotNull(message = "성별은 필수입니다.")
+    private Gender gender;
+
+    @NotNull(message = "마케팅 수신 여부를 선택해주세요.")
+    @JsonProperty("isMarketingAgreed")
+    private Boolean isMarketingAgreed;
+
+    public void toEntity(User user) {
+        user.setNickname(nickname);
+        user.setAddress(address);
+        user.setTel(tel);
+        user.setAge(age);
+        user.setGender(gender);
+        user.setIsMarketingAgreed(isMarketingAgreed);
+        user.setRole(Role.ROLE_USER);
+    }
+}

--- a/src/main/java/com/grepp/funfun/app/controller/api/user/payload/SignupRequest.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/user/payload/SignupRequest.java
@@ -7,6 +7,7 @@ import com.grepp.funfun.app.model.user.entity.User;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.Data;
 
 @Data
@@ -17,6 +18,10 @@ public class SignupRequest {
     private String email;
 
     @NotBlank(message = "비밀번호는 필수입니다.")
+    @Pattern(
+        regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/?]).{8,20}$",
+        message = "비밀번호는 최소 8자리 이상에서 최대 20자리 이하의 영문자, 숫자, 특수문자 조합으로 이루어져야 합니다."
+    )
     private String password;
 
     @NotBlank(message = "닉네임은 필수입니다.")

--- a/src/main/java/com/grepp/funfun/app/controller/api/user/payload/SignupRequest.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/user/payload/SignupRequest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.grepp.funfun.app.model.auth.code.Role;
 import com.grepp.funfun.app.model.user.code.Gender;
 import com.grepp.funfun.app.model.user.entity.User;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -23,6 +24,13 @@ public class SignupRequest {
         message = "비밀번호는 최소 8자리 이상에서 최대 20자리 이하의 영문자, 숫자, 특수문자 조합으로 이루어져야 합니다."
     )
     private String password;
+
+    private String confirmPassword;
+
+    @AssertTrue(message = "비밀번호가 서로 일치하지 않습니다.")
+    public boolean isConfirmPassword() {
+        return password.equals(confirmPassword);
+    }
 
     @NotBlank(message = "닉네임은 필수입니다.")
     private String nickname;

--- a/src/main/java/com/grepp/funfun/app/controller/api/user/payload/VerifyCodeRequest.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/user/payload/VerifyCodeRequest.java
@@ -1,0 +1,12 @@
+package com.grepp.funfun.app.controller.api.user.payload;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Data;
+
+@Data
+public class VerifyCodeRequest {
+    @NotBlank(message = "인증 코드는 필수입니다.")
+    @Pattern(regexp = "^[0-9]{6}$", message = "인증 코드는 6자리 숫자여야 합니다.")
+    private String code;
+}

--- a/src/main/java/com/grepp/funfun/app/model/auth/code/Role.java
+++ b/src/main/java/com/grepp/funfun/app/model/auth/code/Role.java
@@ -2,5 +2,6 @@ package com.grepp.funfun.app.model.auth.code;
 
 public enum Role {
     ROLE_USER,
-    ROLE_ADMIN
+    ROLE_ADMIN,
+    ROLE_GUEST
 }

--- a/src/main/java/com/grepp/funfun/app/model/user/dto/OAuthUserDTO.java
+++ b/src/main/java/com/grepp/funfun/app/model/user/dto/OAuthUserDTO.java
@@ -1,0 +1,14 @@
+package com.grepp.funfun.app.model.user.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class OAuthUserDTO {
+    private String role;
+    private String name;
+    private String email;
+    private String provider;
+    private String providerId;
+}

--- a/src/main/java/com/grepp/funfun/app/model/user/service/UserService.java
+++ b/src/main/java/com/grepp/funfun/app/model/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.grepp.funfun.app.model.user.service;
 
+import com.grepp.funfun.app.controller.api.user.payload.OAuth2SignupRequest;
 import com.grepp.funfun.app.controller.api.user.payload.SignupRequest;
 import com.grepp.funfun.app.model.auth.AuthService;
 import com.grepp.funfun.app.model.auth.dto.TokenDto;
@@ -222,6 +223,17 @@ public class UserService {
         redisTemplate.delete(verifiedKey);
         // 레디스 메일 쿨타임 키 삭제
         redisTemplate.delete(coolDownKey);
+    }
+
+    @Transactional
+    public void updateOAuth2User(String email, OAuth2SignupRequest request) {
+        User user = userRepository.findById(email).orElseThrow(() -> new CommonException(ResponseCode.NOT_FOUND));
+        // 닉네임 중복 검사
+        if (userRepository.existsByNickname(request.getNickname())) {
+            throw new CommonException(ResponseCode.USER_NICKNAME_DUPLICATE);
+        }
+        request.toEntity(user);
+        userRepository.save(user);
     }
 
     public void update(final String email, final UserDTO userDTO) {

--- a/src/main/java/com/grepp/funfun/app/model/user/service/UserService.java
+++ b/src/main/java/com/grepp/funfun/app/model/user/service/UserService.java
@@ -1,6 +1,8 @@
 package com.grepp.funfun.app.model.user.service;
 
 import com.grepp.funfun.app.controller.api.user.payload.SignupRequest;
+import com.grepp.funfun.app.model.auth.AuthService;
+import com.grepp.funfun.app.model.auth.dto.TokenDto;
 import com.grepp.funfun.app.model.contact.entity.Contact;
 import com.grepp.funfun.app.model.contact.repository.ContactRepository;
 import com.grepp.funfun.app.model.group.entity.Group;
@@ -57,6 +59,7 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final MailTemplate mailTemplate;
     private final RedisTemplate<String, Object> redisTemplate;
+    private final AuthService authService;
 
     @Value("${front-server.domain}")
     private String domain;
@@ -134,7 +137,7 @@ public class UserService {
     }
 
     @Transactional
-    public String verifySignupCode(String code) {
+    public TokenDto verifySignupCode(String code) {
         String key = "signup:" + code;
         String email = (String) redisTemplate.opsForValue().get(key);
 
@@ -147,7 +150,7 @@ public class UserService {
         userRepository.save(user);
         redisTemplate.delete(key);
 
-        return email;
+        return authService.processTokenSignin(user.getEmail(), user.getRole().name(), false);
     }
 
     public void update(final String email, final UserDTO userDTO) {

--- a/src/main/java/com/grepp/funfun/infra/auth/jwt/TokenCookieFactory.java
+++ b/src/main/java/com/grepp/funfun/infra/auth/jwt/TokenCookieFactory.java
@@ -5,7 +5,7 @@ import org.springframework.http.ResponseCookie;
 public class TokenCookieFactory {
     public static ResponseCookie create(String name, String value, Long expires) {
         return ResponseCookie.from(name, value)
-                   .maxAge(expires)
+                   .maxAge(expires + 300) // Refresh 토큰 만료기간 보다 5분 길게
                    .path("/")
                    .httpOnly(true)             // HttpOnly
                    .secure(false)

--- a/src/main/java/com/grepp/funfun/infra/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/grepp/funfun/infra/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -101,7 +101,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         RefreshToken newRefreshToken = refreshTokenService.renewingToken(refreshToken.getAtId(), newAccessToken.getJti());
         
         ResponseCookie accessTokenCookie = TokenCookieFactory.create(AuthToken.ACCESS_TOKEN.name(),
-            newAccessToken.getToken(), jwtTokenProvider.getAccessTokenExpiration());
+            newAccessToken.getToken(), newRefreshToken.getTtl());
         
         ResponseCookie refreshTokenCookie = TokenCookieFactory.create(
             AuthToken.REFRESH_TOKEN.name(),

--- a/src/main/java/com/grepp/funfun/infra/auth/oauth2/CustomOauth2UserService.java
+++ b/src/main/java/com/grepp/funfun/infra/auth/oauth2/CustomOauth2UserService.java
@@ -1,0 +1,72 @@
+package com.grepp.funfun.infra.auth.oauth2;
+
+import com.grepp.funfun.app.model.auth.code.Role;
+import com.grepp.funfun.app.model.user.dto.OAuthUserDTO;
+import com.grepp.funfun.app.model.user.entity.User;
+import com.grepp.funfun.app.model.user.repository.UserRepository;
+import com.grepp.funfun.infra.auth.oauth2.user.CustomOAuth2User;
+import com.grepp.funfun.infra.auth.oauth2.user.GoogleOAuth2UserInfo;
+import com.grepp.funfun.infra.auth.oauth2.user.OAuth2UserInfo;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+public class CustomOauth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        log.info("OAuth2 사용자 로드: {}", oAuth2User);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        OAuth2UserInfo oAuth2UserInfo = null;
+
+        if (registrationId.equals("google")) {
+            oAuth2UserInfo = new GoogleOAuth2UserInfo(oAuth2User.getAttributes());
+        } else {
+            return null;
+        }
+
+        String provider = oAuth2UserInfo.getProvider();
+        String providerId = oAuth2UserInfo.getProviderId();
+        String email = oAuth2UserInfo.getEmail();
+        String name = oAuth2UserInfo.getName();
+
+        // 일반 회원가입 계정인지 검사
+        Optional<User> existing = userRepository.findById(email);
+        if (existing.isPresent()) {
+            User user = existing.get();
+            if (!passwordEncoder.matches(providerId, user.getPassword())) {
+                log.warn("이미 일반 회원가입으로 존재하는 이메일입니다: {}", email);
+                throw new OAuth2AuthenticationException(
+                    new OAuth2Error("existing_email", "이미 일반 회원가입된 이메일입니다.", null)
+                );
+            }
+        }
+
+        OAuthUserDTO userDto = new OAuthUserDTO();
+        userDto.setName(name);
+        userDto.setEmail(email);
+        userDto.setRole(Role.ROLE_GUEST.name());
+        userDto.setProvider(provider);
+        userDto.setProviderId(providerId);
+
+        return new CustomOAuth2User(userDto);
+    }
+}

--- a/src/main/java/com/grepp/funfun/infra/auth/oauth2/OAuth2FailureHandler.java
+++ b/src/main/java/com/grepp/funfun/infra/auth/oauth2/OAuth2FailureHandler.java
@@ -1,0 +1,31 @@
+package com.grepp.funfun.infra.auth.oauth2;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class OAuth2FailureHandler implements AuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException exception) throws IOException, ServletException {
+
+        String errorCode = "oauth2_authentication_error"; // 기본값
+
+        if (exception instanceof OAuth2AuthenticationException oae) {
+            errorCode = oae.getError().getErrorCode();
+            log.warn("OAuth2 로그인 실패: {}", oae.getError().getDescription());
+        }
+
+        // NOTE : 프론트 측 URI 로 변경 필요
+        response.sendRedirect("/login/oauth2/error?reason=" + errorCode);
+    }
+}

--- a/src/main/java/com/grepp/funfun/infra/auth/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/grepp/funfun/infra/auth/oauth2/OAuth2SuccessHandler.java
@@ -1,0 +1,94 @@
+package com.grepp.funfun.infra.auth.oauth2;
+
+import com.grepp.funfun.app.model.auth.AuthService;
+import com.grepp.funfun.app.model.auth.code.AuthToken;
+import com.grepp.funfun.app.model.auth.code.Role;
+import com.grepp.funfun.app.model.auth.dto.TokenDto;
+import com.grepp.funfun.app.model.user.entity.User;
+import com.grepp.funfun.app.model.user.entity.UserInfo;
+import com.grepp.funfun.app.model.user.repository.UserInfoRepository;
+import com.grepp.funfun.app.model.user.repository.UserRepository;
+import com.grepp.funfun.infra.auth.jwt.TokenCookieFactory;
+import com.grepp.funfun.infra.auth.oauth2.user.CustomOAuth2User;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final AuthService authService;
+    private final UserRepository userRepository;
+    private final UserInfoRepository userInfoRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+        Authentication authentication) throws IOException, ServletException {
+
+        CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+
+        String email = oAuth2User.getEmail();
+
+        log.info("OAuth2 로그인 성공: email={}", email);
+
+        boolean isExistingUser = userRepository.existsByEmail(email);
+
+        if (!isExistingUser) {
+            User newUser = new User();
+            newUser.setEmail(email);
+            newUser.setPassword(passwordEncoder.encode(oAuth2User.getProviderId()));
+            newUser.setRole(Role.ROLE_GUEST);
+            newUser.setIsVerified(true);
+            UserInfo userInfo = new UserInfo();
+            userInfo.setEmail(email);
+            userInfoRepository.save(userInfo);
+            newUser.setInfo(userInfo);
+
+            userRepository.save(newUser);
+            log.info("OAuth2 사용자 기본 정보 저장: {}", email);
+
+            TokenDto tokenDto = authService.processTokenSignin(email, newUser.getRole().name(), false);
+
+            setAllAuthCookies(response, tokenDto);
+
+            // NOTE : 프론트 측 URI 로 변경 필요
+            response.sendRedirect("/users/oauth2/signup");
+
+        } else {
+            User user = userRepository.findById(email).orElse(null);
+            if (user != null) {
+                TokenDto tokenDto = authService.processTokenSignin(email, user.getRole().name(), false);
+
+                setAllAuthCookies(response, tokenDto);
+
+                if (user.getGroupPreferences() == null || user.getContentPreferences() == null) {
+                    // NOTE : 프론트 측 URI 로 변경 필요
+                    response.sendRedirect("/users/preference");
+                } else {
+                    response.sendRedirect("/");
+                }
+            }
+        }
+    }
+
+    private void setAllAuthCookies(HttpServletResponse response, TokenDto tokenDto) {
+        ResponseCookie accessToken = TokenCookieFactory.create(AuthToken.ACCESS_TOKEN.name(),
+            tokenDto.getAccessToken(), tokenDto.getRefreshExpiresIn());
+        ResponseCookie refreshToken = TokenCookieFactory.create(AuthToken.REFRESH_TOKEN.name(),
+            tokenDto.getRefreshToken(), tokenDto.getRefreshExpiresIn());
+
+        response.addHeader("Set-Cookie", accessToken.toString());
+        response.addHeader("Set-Cookie", refreshToken.toString());
+    }
+}

--- a/src/main/java/com/grepp/funfun/infra/auth/oauth2/user/CustomOAuth2User.java
+++ b/src/main/java/com/grepp/funfun/infra/auth/oauth2/user/CustomOAuth2User.java
@@ -1,0 +1,47 @@
+package com.grepp.funfun.infra.auth.oauth2.user;
+
+import com.grepp.funfun.app.model.user.dto.OAuthUserDTO;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+public class CustomOAuth2User implements OAuth2User {
+    private final OAuthUserDTO userDto;
+
+    public CustomOAuth2User(OAuthUserDTO userDto) {
+        this.userDto = userDto;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority(userDto.getRole()));
+        return authorities;
+    }
+
+    @Override
+    public String getName() {
+        return userDto.getName();
+    }
+
+    public String getEmail() {
+        return userDto.getEmail();
+    }
+
+    public String getProvider() {
+        return userDto.getProvider();
+    }
+
+    public String getProviderId() {
+        return userDto.getProviderId();
+    }
+}

--- a/src/main/java/com/grepp/funfun/infra/auth/oauth2/user/GoogleOAuth2UserInfo.java
+++ b/src/main/java/com/grepp/funfun/infra/auth/oauth2/user/GoogleOAuth2UserInfo.java
@@ -1,0 +1,32 @@
+package com.grepp.funfun.infra.auth.oauth2.user;
+
+import java.util.Map;
+
+public class GoogleOAuth2UserInfo implements OAuth2UserInfo{
+
+    private final Map<String, Object> attribute;
+
+    public GoogleOAuth2UserInfo(Map<String, Object> attribute) {
+        this.attribute = attribute;
+    }
+
+    @Override
+    public String getProvider() {
+        return "google";
+    }
+
+    @Override
+    public String getProviderId() {
+        return attribute.get("sub").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return attribute.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+        return attribute.get("name").toString();
+    }
+}

--- a/src/main/java/com/grepp/funfun/infra/auth/oauth2/user/OAuth2UserInfo.java
+++ b/src/main/java/com/grepp/funfun/infra/auth/oauth2/user/OAuth2UserInfo.java
@@ -1,0 +1,10 @@
+package com.grepp.funfun.infra.auth.oauth2.user;
+
+public interface OAuth2UserInfo {
+
+    String getProviderId();
+    String getProvider();
+    String getName();
+    String getEmail();
+
+}

--- a/src/main/java/com/grepp/funfun/infra/config/security/PasswordEncoderConfig.java
+++ b/src/main/java/com/grepp/funfun/infra/config/security/PasswordEncoderConfig.java
@@ -1,0 +1,14 @@
+package com.grepp.funfun.infra.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+}

--- a/src/main/java/com/grepp/funfun/infra/config/security/SecurityConfig.java
+++ b/src/main/java/com/grepp/funfun/infra/config/security/SecurityConfig.java
@@ -1,8 +1,11 @@
 package com.grepp.funfun.infra.config.security;
 
+import com.grepp.funfun.infra.auth.oauth2.CustomOauth2UserService;
 import com.grepp.funfun.infra.auth.jwt.JwtAuthenticationEntryPoint;
 import com.grepp.funfun.infra.auth.jwt.filter.JwtAuthenticationFilter;
 import com.grepp.funfun.infra.auth.jwt.filter.JwtExceptionFilter;
+import com.grepp.funfun.infra.auth.oauth2.OAuth2FailureHandler;
+import com.grepp.funfun.infra.auth.oauth2.OAuth2SuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
@@ -14,21 +17,23 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.factory.PasswordEncoderFactories;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity(prePostEnabled = true)
 @RequiredArgsConstructor
 public class SecurityConfig {
-    
+
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtExceptionFilter jwtExceptionFilter;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
-    
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final OAuth2FailureHandler oAuth2FailureHandler;
+    private final CustomOauth2UserService customOauth2UserService;
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
@@ -36,31 +41,35 @@ public class SecurityConfig {
             .formLogin(AbstractHttpConfigurer::disable)
             .httpBasic(AbstractHttpConfigurer::disable)
             .cors(Customizer.withDefaults())
+            .oauth2Login((oauth) -> oauth
+                .userInfoEndpoint(endpoint -> endpoint.userService(customOauth2UserService))
+                .successHandler(oAuth2SuccessHandler)
+                .failureHandler(oAuth2FailureHandler)
+            )
             .sessionManagement(
                 session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .logout(AbstractHttpConfigurer::disable)
             .authorizeHttpRequests(
                 (requests) -> requests
-                                  .requestMatchers("/favicon.ico", "/img/**", "/js/**","/css/**").permitAll()
-                                  .requestMatchers("/", "/error", "/auth/login", "/auth/signup").permitAll()
-                                  .requestMatchers("/api/**").permitAll()
-                                  .anyRequest().permitAll()
+                    .requestMatchers("/favicon.ico", "/img/**", "/js/**", "/css/**").permitAll()
+                    .requestMatchers("/", "/error", "/auth/login", "/auth/signup").permitAll()
+                    .requestMatchers("/api/**").permitAll()
+                    // ROLE_GUEST 만 OAuth2 회원가입 페이지 허용
+                    .requestMatchers("/api/users/oauth2").hasRole("GUEST")
+                    .anyRequest().permitAll()
             )
-            // jwtAuthenticationEntryPoint 는 oauth 인증을 사용할 경우 제거
-            .exceptionHandling(ex -> ex.authenticationEntryPoint(jwtAuthenticationEntryPoint))
+            .exceptionHandling(ex -> ex
+                .defaultAuthenticationEntryPointFor(jwtAuthenticationEntryPoint,
+                    new AntPathRequestMatcher("/api/**"))
+            )
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
             .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class);
         return http.build();
     }
-    
+
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
         return (web) -> web.ignoring()
-                            .requestMatchers(PathRequest.toStaticResources().atCommonLocations());
-    }
-    
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+            .requestMatchers(PathRequest.toStaticResources().atCommonLocations());
     }
 }

--- a/src/main/java/com/grepp/funfun/infra/mail/MailTemplate.java
+++ b/src/main/java/com/grepp/funfun/infra/mail/MailTemplate.java
@@ -1,0 +1,37 @@
+package com.grepp.funfun.infra.mail;
+
+import jakarta.mail.Message.RecipientType;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.stereotype.Component;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+@Component
+@RequiredArgsConstructor
+@Setter
+@EnableAsync
+public class MailTemplate {
+
+    private final JavaMailSender javaMailSender;
+    private final TemplateEngine templateEngine;
+
+    @Async
+    public void send(SmtpDto dto){
+        javaMailSender.send(mimeMessage -> {
+            mimeMessage.setFrom(dto.getFrom());
+            mimeMessage.addRecipients(RecipientType.TO, dto.getTo());
+            mimeMessage.setSubject(dto.getSubject());
+            mimeMessage.setText(render(dto), "UTF-8", "html");
+        });
+    }
+
+    private String render(SmtpDto dto) {
+        Context context = new Context();
+        context.setVariables(dto.getProperties());
+        return templateEngine.process(dto.getTemplatePath(), context);
+    }
+}

--- a/src/main/java/com/grepp/funfun/infra/mail/SmtpDto.java
+++ b/src/main/java/com/grepp/funfun/infra/mail/SmtpDto.java
@@ -1,0 +1,15 @@
+package com.grepp.funfun.infra.mail;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import lombok.Data;
+
+@Data
+public class SmtpDto {
+    private String templatePath;
+    private String to;
+    private String from;
+    private String subject;
+    // thymeleaf 의 context 에 전달할 데이터 저장
+    private Map<String, Object> properties = new LinkedHashMap<>();
+}

--- a/src/main/java/com/grepp/funfun/infra/response/ResponseCode.java
+++ b/src/main/java/com/grepp/funfun/infra/response/ResponseCode.java
@@ -17,6 +17,8 @@ public enum ResponseCode {
     USER_NOT_VERIFY("4017", HttpStatus.BAD_REQUEST, "이메일 인증이 되지 않은 사용자입니다"),
     USER_SUSPENDED("4018", HttpStatus.BAD_REQUEST, "정지된 사용자입니다."),
     USER_INACTIVE("4019", HttpStatus.BAD_REQUEST, "비활성화된 사용자입니다."),
+    INVALID_AUTH_CODE("4020", HttpStatus.BAD_REQUEST, "잘못된 인증 코드입니다."),
+    TOO_FAST_VERIFY_REQUEST("4021", HttpStatus.BAD_REQUEST, "인증 메일은 3분마다 발송할 수 있습니다."),
     INTERNAL_SERVER_ERROR("5000", HttpStatus.INTERNAL_SERVER_ERROR, "서버에러 입니다."),
     SECURITY_INCIDENT("6000", HttpStatus.OK, "비정상적인 로그인 시도가 감지되었습니다.");
     

--- a/src/main/java/com/grepp/funfun/infra/response/ResponseCode.java
+++ b/src/main/java/com/grepp/funfun/infra/response/ResponseCode.java
@@ -12,6 +12,8 @@ public enum ResponseCode {
     NOT_EXIST_PRE_AUTH_CREDENTIAL("4012", HttpStatus.OK, "사전 인증 정보가 요청에서 발견되지 않았습니다."),
     USER_EMAIL_DUPLICATE("4013", HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
     USER_NICKNAME_DUPLICATE("4014", HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
+    BAD_USER_VERIFY("4015", HttpStatus.BAD_REQUEST, "인증 링크가 만료되었거나 잘못되었습니다."),
+    ALREADY_VERIFIED("4016", HttpStatus.BAD_REQUEST, "이미 인증된 사용자입니다."),
     INTERNAL_SERVER_ERROR("5000", HttpStatus.INTERNAL_SERVER_ERROR, "서버에러 입니다."),
     SECURITY_INCIDENT("6000", HttpStatus.OK, "비정상적인 로그인 시도가 감지되었습니다.");
     

--- a/src/main/java/com/grepp/funfun/infra/response/ResponseCode.java
+++ b/src/main/java/com/grepp/funfun/infra/response/ResponseCode.java
@@ -14,6 +14,9 @@ public enum ResponseCode {
     USER_NICKNAME_DUPLICATE("4014", HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
     BAD_USER_VERIFY("4015", HttpStatus.BAD_REQUEST, "인증 링크가 만료되었거나 잘못되었습니다."),
     ALREADY_VERIFIED("4016", HttpStatus.BAD_REQUEST, "이미 인증된 사용자입니다."),
+    USER_NOT_VERIFY("4017", HttpStatus.BAD_REQUEST, "이메일 인증이 되지 않은 사용자입니다"),
+    USER_SUSPENDED("4018", HttpStatus.BAD_REQUEST, "정지된 사용자입니다."),
+    USER_INACTIVE("4019", HttpStatus.BAD_REQUEST, "비활성화된 사용자입니다."),
     INTERNAL_SERVER_ERROR("5000", HttpStatus.INTERNAL_SERVER_ERROR, "서버에러 입니다."),
     SECURITY_INCIDENT("6000", HttpStatus.OK, "비정상적인 로그인 시도가 감지되었습니다.");
     

--- a/src/main/resources/templates/mail/code-verification.html
+++ b/src/main/resources/templates/mail/code-verification.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>맛남 이메일 인증</title>
+</head>
+<body style="margin: 0; padding: 0; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; background-color: #f4f4f4;">
+
+<!-- 이메일 미리보기 텍스트 -->
+<div style="display: none; font-size: 1px; color: #fefefe; line-height: 1px; max-height: 0px; max-width: 0px; opacity: 0; overflow: hidden;">
+  FunFun 인증 코드입니다.
+</div>
+
+<table border="0" cellpadding="0" cellspacing="0" width="100%" style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); padding: 20px 0;">
+
+  <!-- 메인 컨테이너 -->
+  <tr>
+    <td align="center">
+      <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px;">
+
+        <!-- 메인 콘텐츠 -->
+        <tr>
+          <td style="background: white; padding: 40px 30px; text-align: center;">
+
+            <p style="font-size: 18px; color: #333; line-height: 1.6; margin: 0 0 30px 0;">
+              <strong style="color: #FFA73B; font-weight: 600;">FunFun</strong>인증 코드입니다.<br>
+            </p>
+
+            <!-- 인증 버튼 -->
+            <table border="0" cellspacing="0" cellpadding="0" style="margin: 30px auto;">
+              <tr>
+                <td style="background: linear-gradient(45deg, #FFA73B, #ff9500); border-radius: 50px; box-shadow: 0 8px 25px rgba(255, 167, 59, 0.4);" th:text="${code}">
+                </td>
+              </tr>
+            </table>
+
+            <p>이 코드는 5분간 유효합니다.</p>
+          </td>
+        </tr>
+
+        <!-- 팀 서명 -->
+        <tr>
+          <td style="background: white; padding: 30px; text-align: center; border-radius: 0 0 20px 20px;">
+            <p style="color: #333; font-weight: 600; margin: 0;">
+              감사합니다,<br>
+              <strong style="color: #FFA73B;">FunFun 팀</strong> 💜
+            </p>
+          </td>
+        </tr>
+
+      </table>
+    </td>
+  </tr>
+</table>
+
+</body>
+</html>

--- a/src/main/resources/templates/mail/signup-verification.html
+++ b/src/main/resources/templates/mail/signup-verification.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>맛남 이메일 인증</title>
+</head>
+<body style="margin: 0; padding: 0; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; background-color: #f4f4f4;">
+
+<!-- 이메일 미리보기 텍스트 -->
+<div style="display: none; font-size: 1px; color: #fefefe; line-height: 1px; max-height: 0px; max-width: 0px; opacity: 0; overflow: hidden;">
+  FunFun에 오신 것을 환영합니다! 이메일 인증을 완료하고 모든 기능을 이용해보세요. 🎉
+</div>
+
+<table border="0" cellpadding="0" cellspacing="0" width="100%" style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); padding: 20px 0;">
+
+  <!-- 메인 컨테이너 -->
+  <tr>
+    <td align="center">
+      <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px;">
+
+        <!-- 헤더 섹션 -->
+        <tr>
+          <td style="background: linear-gradient(45deg, #FFA73B, #ff9500); padding: 40px 20px; text-align: center; border-radius: 20px 20px 0 0;">
+
+            <!-- 아이콘 -->
+            <div style="width: 100px; height: 100px; background: rgba(255, 255, 255, 0.2); border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; margin-bottom: 20px; border: 3px solid rgba(255, 255, 255, 0.3);">
+              <img src="https://img.icons8.com/fluency-systems-filled/96/ffffff/user.png" width="50" height="50" style="display: block;" alt="환영합니다" />
+            </div>
+
+            <!-- 환영 메시지 -->
+            <h1 style="color: white; font-size: 28px; font-weight: 600; margin: 0; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);">
+              🎉 환영합니다, <span th:text="${nickname}">닉네임</span>님!
+            </h1>
+          </td>
+        </tr>
+
+        <!-- 메인 콘텐츠 -->
+        <tr>
+          <td style="background: white; padding: 40px 30px; text-align: center;">
+
+            <!-- 환영 메시지 -->
+            <p style="font-size: 18px; color: #333; line-height: 1.6; margin: 0 0 30px 0;">
+              <strong style="color: #FFA73B; font-weight: 600;">FunFun</strong>에 가입해주셔서 감사합니다!<br>
+              모든 기능을 이용하시려면 먼저 이메일 인증을 완료해주세요.<br>
+              아래 버튼을 클릭하시면 인증이 완료됩니다.
+            </p>
+
+            <!-- 인증 버튼 -->
+            <table border="0" cellspacing="0" cellpadding="0" style="margin: 30px auto;">
+              <tr>
+                <td style="background: linear-gradient(45deg, #FFA73B, #ff9500); border-radius: 50px; box-shadow: 0 8px 25px rgba(255, 167, 59, 0.4);">
+                  <a th:href="|${domain}/user/verify?code=${code}|"
+                     target="_blank"
+                     style="display: inline-block; padding: 16px 40px; color: white; text-decoration: none; font-size: 18px; font-weight: 600; border-radius: 50px;">
+                    ✉️ 이메일 인증하기
+                  </a>
+                </td>
+              </tr>
+            </table>
+
+            <p>이 링크는 5분간 유효합니다.</p>
+          </td>
+        </tr>
+
+        <!-- 팀 서명 -->
+        <tr>
+          <td style="background: white; padding: 30px; text-align: center; border-radius: 0 0 20px 20px;">
+            <p style="color: #333; font-weight: 600; margin: 0;">
+              감사합니다,<br>
+              <strong style="color: #FFA73B;">FunFun 팀</strong> 💜
+            </p>
+          </td>
+        </tr>
+
+      </table>
+    </td>
+  </tr>
+</table>
+
+</body>
+</html>


### PR DESCRIPTION
## 📌 과제 설명 
* JWT Token 쿠키 만료 기간 수정
* 메일 인증 기능
* 로그인 로직 수정
* 비밀번호 변경 기능
* OAuth2 구글 로그인

## 👩‍💻 요구 사항과 구현 내용
* JWT Token 쿠키 만료 기간 수정
    * 액세스 토큰, 리프레시 토큰 쿠키 모두 리프레시 토큰 만료기간보다 5분 길게 설정했습니다.
* 메일 인증 기능
    * 회원 가입 시 인증 링크 메일
        * 레디스를 통해 5분간 유효한 링크로 설정했습니다.
        * 인증 완료 시 자동 로그인 처리됩니다.
    * 인증 코드 메일
        * 비밀번호 변경이나 닉네임 변경과 같은 회원이 인증이 필요한 경우 발송하는 6자리 랜덤 코드입니다.
        * 레디스를 통해 5분간 유효한 코드로 설정했습니다.
        * 인증 코드 검증 후 10분간 유효한 인증 키를 저장합니다.
    * 메일 발송 시 쿨타임을 적용했습니다. 3분에 한 번씩 메일을 보낼 수 있습니다.
* 회원 가입, 비밀번호 변경 시 비밀번호 유효성 검사
    * 비밀번호는 최소 8자리 이상에서 최대 20자리 이하의 영문자, 숫자, 특수문자 조합으로 이루어져야 합니다.
* 비밀번호 변경 기능
    * 인증을 한 상태인지 검증
    * 비밀번호 암호화
    * 레디스 인증 키, 쿨타임 키 삭제
* 회원가입 시에도 비밀번호 확인 필드 추가
* OAuth2 구글 로그인
    * OAuth2 계정이 일반 회원가입 계정으로 존재할 경우 예외 처리
    * ROLE_GUEST 권한 추가
    * OAuth2 회원가입 기능 (ROLE_GUEST만 가능)
## ✅ PR 포인트 & 궁금한 점
* ROLE 권한 데이터 추가로 테이블 CREATE로 다시 생성해 주셔야 합니다.
* application-local.properties에서 추가 사항있습니다.
추가된 사항
```
# smtp
spring.mail.host=smtp.gmail.com
spring.mail.username=메일 보낼 구글 이메일
spring.mail.password=구글 앱 비밀번호
spring.mail.properties.mail.smtp.auth=true
spring.mail.properties.mail.smtp.starttls.enable=true

# oauth2 - google
spring.security.oauth2.client.registration.google.client-name=google
spring.security.oauth2.client.registration.google.client-id=노션에 작성했습니다.
spring.security.oauth2.client.registration.google.client-secret=노션에 작성했습니다.
spring.security.oauth2.client.registration.google.redirect-uri=http://localhost:8080/login/oauth2/code/google
spring.security.oauth2.client.registration.google.authorization-grant-type=authorization_code
spring.security.oauth2.client.registration.google.scope=profile,email
```
