### PR TITLE
feat: 사용자 추가 기능 구현

### DIFF
--- a/src/main/java/com/grepp/funfun/app/controller/api/auth/AuthApiController.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/auth/AuthApiController.java
@@ -7,6 +7,7 @@ import com.grepp.funfun.app.model.auth.code.AuthToken;
 import com.grepp.funfun.app.model.auth.dto.TokenDto;
 import com.grepp.funfun.infra.auth.jwt.TokenCookieFactory;
 import com.grepp.funfun.infra.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,7 @@ public class AuthApiController {
     private final AuthService authService;
     
     @PostMapping("/login")
+    @Operation(summary = "로그인", description = "로그인 성공 시 AccessToken 쿠키와 RefreshToken 쿠키를 발급합니다.")
     public ResponseEntity<ApiResponse<TokenResponse>> login(
         @RequestBody @Valid LoginRequest loginRequest,
         HttpServletResponse response

--- a/src/main/java/com/grepp/funfun/app/controller/api/user/UserApiController.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/user/UserApiController.java
@@ -1,7 +1,7 @@
 package com.grepp.funfun.app.controller.api.user;
 
 import com.grepp.funfun.app.controller.api.auth.payload.TokenResponse;
-import com.grepp.funfun.app.controller.api.user.payload.ChangeNicknameRequest;
+import com.grepp.funfun.app.controller.api.user.payload.NicknameRequest;
 import com.grepp.funfun.app.controller.api.user.payload.ChangePasswordRequest;
 import com.grepp.funfun.app.controller.api.user.payload.OAuth2SignupRequest;
 import com.grepp.funfun.app.controller.api.user.payload.SignupRequest;
@@ -142,10 +142,17 @@ public class UserApiController {
     @PatchMapping("/change/nickname")
     @Operation(summary = "닉네임 변경", description = "인증 코드로 인증된 사용자에 한해서 닉네임 변경을 진행합니다.")
     public ResponseEntity<ApiResponse<String>> changeNickname(@RequestBody @Valid
-    ChangeNicknameRequest request, Authentication authentication) {
+    NicknameRequest request, Authentication authentication) {
         String email = authentication.getName();
         userService.changeNickname(email, request.getNickname());
 
         return ResponseEntity.ok(ApiResponse.success("닉네임 변경이 완료되었습니다."));
+    }
+
+    @PostMapping("/verify/nickname")
+    @Operation(summary = "닉네임 중복 검사", description = "중복된 닉네임인지 검증합니다.")
+    public ResponseEntity<ApiResponse<String>> verifyNickname(@RequestBody @Valid NicknameRequest request) {
+        userService.verifyNickname(request.getNickname());
+        return ResponseEntity.ok(ApiResponse.success("사용 가능한 닉네임입니다."));
     }
 }

--- a/src/main/java/com/grepp/funfun/app/controller/api/user/UserApiController.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/user/UserApiController.java
@@ -13,6 +13,7 @@ import com.grepp.funfun.infra.auth.jwt.TokenCookieFactory;
 import com.grepp.funfun.infra.response.ApiResponse;
 import com.grepp.funfun.util.ReferencedException;
 import com.grepp.funfun.util.ReferencedWarning;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -53,12 +54,14 @@ public class UserApiController {
     }
 
     @PostMapping
+    @Operation(summary = "회원가입", description = "회원가입을 진행 후 인증 메일을 발송합니다.")
     public ResponseEntity<ApiResponse<String>> createUser(@RequestBody @Valid SignupRequest request) {
         String createdEmail = userService.create(request);
         return ResponseEntity.ok(ApiResponse.success(createdEmail));
     }
 
     @PatchMapping("/oauth2")
+    @Operation(summary = "OAuth2 회원가입", description = "소셜 로그인 대상의 추가 정보를 입력 받습니다.")
     public ResponseEntity<ApiResponse<String>> updateOAuth2User(@RequestBody @Valid OAuth2SignupRequest request, Authentication authentication) {
         String email = authentication.getName();
         userService.updateOAuth2User(email, request);
@@ -83,6 +86,7 @@ public class UserApiController {
     }
 
     @PostMapping("/verify/signup")
+    @Operation(summary = "회원가입 이메일 인증", description = "회원가입 이메일 인증을 진행합니다.")
     public ResponseEntity<ApiResponse<TokenResponse>> verifySignup(@RequestParam("code") String code,  HttpServletResponse response) {
         TokenDto tokenDto = userService.verifySignupCode(code);
 
@@ -102,12 +106,14 @@ public class UserApiController {
     }
 
     @PostMapping("/send/signup/{email}")
+    @Operation(summary = "회원가입 인증 메일 재발송", description = "회원가입 인증 메일을 재발송합니다.<br>쿨타임은 3분이며, 링크는 5분간 유효합니다.")
     public ResponseEntity<ApiResponse<String>> resendVerificationSignupMail(@PathVariable("email") String email) {
         userService.resendVerificationSignupEmail(email);
         return ResponseEntity.ok(ApiResponse.success(email));
     }
 
     @PostMapping("/send/code")
+    @Operation(summary = "인증 코드 메일 발송", description = "인증 코드 메일을 발송합니다.<br>쿨타임은 3분이며, 인증 코드는 5분간 유효합니다.<br>인증 키는 10분간 유효합니다.")
     public ResponseEntity<ApiResponse<String>> sendCode(Authentication authentication) {
         String email = authentication.getName();
         userService.sendCode(email);
@@ -115,6 +121,7 @@ public class UserApiController {
     }
 
     @PostMapping("/verify/code")
+    @Operation(summary = "인증 코드 검증", description = "올바른 인증 코드인지 검증합니다.")
     public ResponseEntity<ApiResponse<String>> verifyCode(@RequestBody @Valid VerifyCodeRequest request, Authentication authentication) {
         String email = authentication.getName();
         userService.verifyCode(email, request.getCode());
@@ -122,6 +129,7 @@ public class UserApiController {
     }
 
     @PatchMapping("/change/password")
+    @Operation(summary = "비밀번호 변경", description = "인증 코드로 인증된 사용자에 한해서 비밀번호 변경을 진행합니다.")
     public ResponseEntity<ApiResponse<String>> changePassword(@RequestBody @Valid
         ChangePasswordRequest request, Authentication authentication) {
         String email = authentication.getName();

--- a/src/main/java/com/grepp/funfun/app/controller/api/user/UserApiController.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/user/UserApiController.java
@@ -109,7 +109,7 @@ public class UserApiController {
     }
 
     @PostMapping("/verify/signup")
-    @Operation(summary = "회원가입 이메일 인증", description = "회원가입 이메일 인증을 진행합니다.")
+    @Operation(summary = "회원가입 이메일 인증", description = "회원가입 이메일 인증을 진행합니다.<br>자동으로 로그인됩니다.")
     public ResponseEntity<ApiResponse<TokenResponse>> verifySignup(@RequestParam("code") String code,  HttpServletResponse response) {
         TokenDto tokenDto = userService.verifySignupCode(code);
 

--- a/src/main/java/com/grepp/funfun/app/controller/api/user/UserApiController.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/user/UserApiController.java
@@ -1,6 +1,7 @@
 package com.grepp.funfun.app.controller.api.user;
 
 import com.grepp.funfun.app.controller.api.auth.payload.TokenResponse;
+import com.grepp.funfun.app.controller.api.user.payload.ChangeNicknameRequest;
 import com.grepp.funfun.app.controller.api.user.payload.ChangePasswordRequest;
 import com.grepp.funfun.app.controller.api.user.payload.OAuth2SignupRequest;
 import com.grepp.funfun.app.controller.api.user.payload.SignupRequest;
@@ -136,5 +137,15 @@ public class UserApiController {
         userService.changePassword(email, request.getPassword());
 
         return ResponseEntity.ok(ApiResponse.success("비밀번호 변경이 완료되었습니다."));
+    }
+
+    @PatchMapping("/change/nickname")
+    @Operation(summary = "닉네임 변경", description = "인증 코드로 인증된 사용자에 한해서 닉네임 변경을 진행합니다.")
+    public ResponseEntity<ApiResponse<String>> changeNickname(@RequestBody @Valid
+    ChangeNicknameRequest request, Authentication authentication) {
+        String email = authentication.getName();
+        userService.changeNickname(email, request.getNickname());
+
+        return ResponseEntity.ok(ApiResponse.success("닉네임 변경이 완료되었습니다."));
     }
 }

--- a/src/main/java/com/grepp/funfun/app/controller/api/user/payload/ChangeNicknameRequest.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/user/payload/ChangeNicknameRequest.java
@@ -1,0 +1,15 @@
+package com.grepp.funfun.app.controller.api.user.payload;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Data;
+
+@Data
+public class ChangeNicknameRequest {
+    @NotBlank(message = "닉네임은 필수입니다.")
+    @Pattern(
+        regexp = "^[가-힣a-zA-Z0-9]{2,10}$",
+        message = "닉네임은 한글, 영문, 숫자만 사용할 수 있으며, 2자 이상 10자 이하로 입력해야 합니다."
+    )
+    private String nickname;
+}

--- a/src/main/java/com/grepp/funfun/app/controller/api/user/payload/ChangePasswordRequest.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/user/payload/ChangePasswordRequest.java
@@ -10,7 +10,7 @@ public class ChangePasswordRequest {
     @NotBlank(message = "비밀번호는 필수입니다.")
     @Pattern(
         regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/?]).{8,20}$",
-        message = "비밀번호는 최소 8자리 이상에서 최대 20자리 이하의 영문자, 숫자, 특수문자 조합으로 이루어져야 합니다."
+        message = "8~20자 영문, 숫자, 특수문자 조합이어야 합니다"
     )
     private String password;
 

--- a/src/main/java/com/grepp/funfun/app/controller/api/user/payload/NicknameRequest.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/user/payload/NicknameRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.Pattern;
 import lombok.Data;
 
 @Data
-public class ChangeNicknameRequest {
+public class NicknameRequest {
     @NotBlank(message = "닉네임은 필수입니다.")
     @Pattern(
         regexp = "^[가-힣a-zA-Z0-9]{2,10}$",

--- a/src/main/java/com/grepp/funfun/app/controller/api/user/payload/OAuth2SignupRequest.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/user/payload/OAuth2SignupRequest.java
@@ -4,8 +4,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.grepp.funfun.app.model.auth.code.Role;
 import com.grepp.funfun.app.model.user.code.Gender;
 import com.grepp.funfun.app.model.user.entity.User;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import lombok.Data;
 
 @Data
@@ -17,11 +21,18 @@ public class OAuth2SignupRequest {
     @NotBlank(message = "주소는 필수입니다.")
     private String address;
 
-    @NotBlank(message = "전화번호는 필수입니다.")
-    private String tel;
+    @NotBlank(message = "생년월일은 필수입니다.")
+    private String birthDate;
 
-    @NotNull(message = "나이는 필수입니다.")
-    private int age;
+    @AssertTrue(message = "생년월일은 yyyyMMdd 형식의 유효한 날짜여야 합니다.")
+    public boolean isBirthDate() {
+        try {
+            LocalDate.parse(birthDate, DateTimeFormatter.ofPattern("yyyyMMdd"));
+            return true;
+        } catch (DateTimeParseException e) {
+            return false;
+        }
+    }
 
     @NotNull(message = "성별은 필수입니다.")
     private Gender gender;
@@ -33,8 +44,7 @@ public class OAuth2SignupRequest {
     public void toEntity(User user) {
         user.setNickname(nickname);
         user.setAddress(address);
-        user.setTel(tel);
-        user.setAge(age);
+        user.setBirthDate(birthDate);
         user.setGender(gender);
         user.setIsMarketingAgreed(isMarketingAgreed);
         user.setRole(Role.ROLE_USER);

--- a/src/main/java/com/grepp/funfun/app/controller/api/user/payload/SignupRequest.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/user/payload/SignupRequest.java
@@ -9,6 +9,9 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import lombok.Data;
 
 @Data
@@ -42,11 +45,18 @@ public class SignupRequest {
     @NotBlank(message = "주소는 필수입니다.")
     private String address;
 
-    @NotBlank(message = "전화번호는 필수입니다.")
-    private String tel;
+    @NotBlank(message = "생년월일은 필수입니다.")
+    private String birthDate;
 
-    @NotNull(message = "나이는 필수입니다.")
-    private int age;
+    @AssertTrue(message = "생년월일은 yyyyMMdd 형식의 유효한 날짜여야 합니다.")
+    public boolean isBirthDate() {
+        try {
+            LocalDate.parse(birthDate, DateTimeFormatter.ofPattern("yyyyMMdd"));
+            return true;
+        } catch (DateTimeParseException e) {
+            return false;
+        }
+    }
 
     @NotNull(message = "성별은 필수입니다.")
     private Gender gender;
@@ -61,8 +71,7 @@ public class SignupRequest {
         user.setEmail(email);
         user.setNickname(nickname);
         user.setAddress(address);
-        user.setTel(tel);
-        user.setAge(age);
+        user.setBirthDate(birthDate);
         user.setGender(gender);
         user.setIsMarketingAgreed(isMarketingAgreed);
         user.setRole(Role.ROLE_USER);

--- a/src/main/java/com/grepp/funfun/app/controller/api/user/payload/SignupRequest.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/user/payload/SignupRequest.java
@@ -21,7 +21,7 @@ public class SignupRequest {
     @NotBlank(message = "비밀번호는 필수입니다.")
     @Pattern(
         regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/?]).{8,20}$",
-        message = "비밀번호는 최소 8자리 이상에서 최대 20자리 이하의 영문자, 숫자, 특수문자 조합으로 이루어져야 합니다."
+        message = "8~20자 영문, 숫자, 특수문자 조합이어야 합니다"
     )
     private String password;
 
@@ -33,6 +33,10 @@ public class SignupRequest {
     }
 
     @NotBlank(message = "닉네임은 필수입니다.")
+    @Pattern(
+        regexp = "^[가-힣a-zA-Z0-9]{2,10}$",
+        message = "닉네임은 한글, 영문, 숫자만 사용할 수 있으며, 2자 이상 10자 이하로 입력해야 합니다."
+    )
     private String nickname;
 
     @NotBlank(message = "주소는 필수입니다.")

--- a/src/main/java/com/grepp/funfun/app/model/user/entity/User.java
+++ b/src/main/java/com/grepp/funfun/app/model/user/entity/User.java
@@ -35,12 +35,10 @@ public class User extends BaseEntity {
 
     private String nickname;
 
-    private Integer age;
+    private String birthDate;
 
     @Enumerated(EnumType.STRING)
     private Gender gender;
-
-    private String tel;
 
     private String address;
 

--- a/src/main/java/com/grepp/funfun/app/model/user/service/UserService.java
+++ b/src/main/java/com/grepp/funfun/app/model/user/service/UserService.java
@@ -293,9 +293,7 @@ public class UserService {
         userDTO.setEmail(user.getEmail());
         userDTO.setPassword(user.getPassword());
         userDTO.setNickname(user.getNickname());
-        userDTO.setAge(user.getAge());
         userDTO.setGender(user.getGender());
-        userDTO.setTel(user.getTel());
         userDTO.setAddress(user.getAddress());
         userDTO.setRole(user.getRole());
         userDTO.setStatus(user.getStatus());
@@ -311,9 +309,7 @@ public class UserService {
     private User mapToEntity(final UserDTO userDTO, final User user) {
         user.setPassword(userDTO.getPassword());
         user.setNickname(userDTO.getNickname());
-        user.setAge(userDTO.getAge());
         user.setGender(userDTO.getGender());
-        user.setTel(userDTO.getTel());
         user.setAddress(userDTO.getAddress());
         user.setRole(userDTO.getRole());
         user.setStatus(userDTO.getStatus());

--- a/src/main/java/com/grepp/funfun/app/model/user/service/UserService.java
+++ b/src/main/java/com/grepp/funfun/app/model/user/service/UserService.java
@@ -133,7 +133,7 @@ public class UserService {
 
         SmtpDto smtpDto = new SmtpDto();
         smtpDto.setTo(user.getEmail());
-        smtpDto.setTemplatePath("/mail/signup-verification");
+        smtpDto.setTemplatePath("mail/signup-verification");
         smtpDto.setSubject("회원가입을 환영합니다!");
         smtpDto.setProperties(Map.of("domain", domain, "code", code, "nickname", user.getNickname()));
 
@@ -170,7 +170,7 @@ public class UserService {
 
         SmtpDto smtpDto = new SmtpDto();
         smtpDto.setTo(user.getEmail());
-        smtpDto.setTemplatePath("/mail/code-verification");
+        smtpDto.setTemplatePath("mail/code-verification");
         smtpDto.setSubject("FunFun 인증 코드");
         smtpDto.setProperties(Map.of("code", code));
 

--- a/src/main/java/com/grepp/funfun/app/model/user/service/UserService.java
+++ b/src/main/java/com/grepp/funfun/app/model/user/service/UserService.java
@@ -260,6 +260,13 @@ public class UserService {
         redisTemplate.delete(coolDownKey);
     }
 
+    public void verifyNickname(String nickname) {
+        // 닉네임 중복 검사
+        if (userRepository.existsByNickname(nickname)) {
+            throw new CommonException(ResponseCode.USER_NICKNAME_DUPLICATE);
+        }
+    }
+
     public void update(final String email, final UserDTO userDTO) {
         final User user = userRepository.findById(email)
             .orElseThrow(() -> new CommonException(ResponseCode.NOT_FOUND));

--- a/src/main/java/com/grepp/funfun/app/model/user/service/UserService.java
+++ b/src/main/java/com/grepp/funfun/app/model/user/service/UserService.java
@@ -4,6 +4,7 @@ import com.grepp.funfun.app.controller.api.user.payload.OAuth2SignupRequest;
 import com.grepp.funfun.app.controller.api.user.payload.SignupRequest;
 import com.grepp.funfun.app.model.auth.AuthService;
 import com.grepp.funfun.app.model.auth.dto.TokenDto;
+import com.grepp.funfun.app.model.auth.token.RefreshTokenService;
 import com.grepp.funfun.app.model.contact.entity.Contact;
 import com.grepp.funfun.app.model.contact.repository.ContactRepository;
 import com.grepp.funfun.app.model.group.entity.Group;
@@ -62,6 +63,7 @@ public class UserService {
     private final MailTemplate mailTemplate;
     private final RedisTemplate<String, Object> redisTemplate;
     private final AuthService authService;
+    private final RefreshTokenService refreshTokenService;
 
     @Value("${front-server.domain}")
     private String domain;
@@ -265,6 +267,15 @@ public class UserService {
         if (userRepository.existsByNickname(nickname)) {
             throw new CommonException(ResponseCode.USER_NICKNAME_DUPLICATE);
         }
+    }
+
+    @Transactional
+    public void unActive(String email, String accessTokenId) {
+        User user = userRepository.findById(email).orElseThrow(() -> new CommonException(ResponseCode.NOT_FOUND));
+        user.unActivated();
+        userRepository.save(user);
+
+        refreshTokenService.deleteByAccessTokenId(accessTokenId);
     }
 
     public void update(final String email, final UserDTO userDTO) {

--- a/src/main/java/com/grepp/funfun/infra/auth/oauth2/CustomOauth2UserService.java
+++ b/src/main/java/com/grepp/funfun/infra/auth/oauth2/CustomOauth2UserService.java
@@ -6,7 +6,9 @@ import com.grepp.funfun.app.model.user.entity.User;
 import com.grepp.funfun.app.model.user.repository.UserRepository;
 import com.grepp.funfun.infra.auth.oauth2.user.CustomOAuth2User;
 import com.grepp.funfun.infra.auth.oauth2.user.GoogleOAuth2UserInfo;
+import com.grepp.funfun.infra.auth.oauth2.user.NaverOAuth2UserInfo;
 import com.grepp.funfun.infra.auth.oauth2.user.OAuth2UserInfo;
+import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,8 +41,8 @@ public class CustomOauth2UserService extends DefaultOAuth2UserService {
 
         if (registrationId.equals("google")) {
             oAuth2UserInfo = new GoogleOAuth2UserInfo(oAuth2User.getAttributes());
-        } else {
-            return null;
+        } else if (registrationId.equals("naver")){
+            oAuth2UserInfo = new NaverOAuth2UserInfo((Map)oAuth2User.getAttributes().get("response"));
         }
 
         String provider = oAuth2UserInfo.getProvider();
@@ -53,9 +55,9 @@ public class CustomOauth2UserService extends DefaultOAuth2UserService {
         if (existing.isPresent()) {
             User user = existing.get();
             if (!passwordEncoder.matches(providerId, user.getPassword())) {
-                log.warn("이미 일반 회원가입으로 존재하는 이메일입니다: {}", email);
+                log.warn("이미 존재하는 이메일입니다: {}", email);
                 throw new OAuth2AuthenticationException(
-                    new OAuth2Error("existing_email", "이미 일반 회원가입된 이메일입니다.", null)
+                    new OAuth2Error("existing_email", "이미 회원가입된 이메일입니다.", null)
                 );
             }
         }

--- a/src/main/java/com/grepp/funfun/infra/auth/oauth2/user/NaverOAuth2UserInfo.java
+++ b/src/main/java/com/grepp/funfun/infra/auth/oauth2/user/NaverOAuth2UserInfo.java
@@ -1,0 +1,32 @@
+package com.grepp.funfun.infra.auth.oauth2.user;
+
+import java.util.Map;
+
+public class NaverOAuth2UserInfo implements OAuth2UserInfo{
+
+    private final Map<String, Object> attribute;
+
+    public NaverOAuth2UserInfo(Map<String, Object> attribute) {
+        this.attribute = attribute;
+    }
+
+    @Override
+    public String getProvider() {
+        return "naver";
+    }
+
+    @Override
+    public String getProviderId() {
+        return attribute.get("id").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return attribute.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+        return attribute.get("name").toString();
+    }
+}

--- a/src/main/java/com/grepp/funfun/infra/response/ResponseCode.java
+++ b/src/main/java/com/grepp/funfun/infra/response/ResponseCode.java
@@ -11,7 +11,7 @@ public enum ResponseCode {
     NOT_FOUND("4040", HttpStatus.NOT_FOUND, "NOT FOUND"),
     NOT_EXIST_PRE_AUTH_CREDENTIAL("4012", HttpStatus.OK, "사전 인증 정보가 요청에서 발견되지 않았습니다."),
     USER_EMAIL_DUPLICATE("4013", HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
-    USER_NICKNAME_DUPLICATE("4014", HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
+    USER_NICKNAME_DUPLICATE("4014", HttpStatus.BAD_REQUEST, "이미 사용 중인 닉네임입니다."),
     BAD_USER_VERIFY("4015", HttpStatus.BAD_REQUEST, "인증 링크가 만료되었거나 잘못되었습니다."),
     ALREADY_VERIFIED("4016", HttpStatus.BAD_REQUEST, "이미 인증된 사용자입니다."),
     USER_NOT_VERIFY("4017", HttpStatus.BAD_REQUEST, "이메일 인증이 되지 않은 사용자입니다"),


### PR DESCRIPTION
## 📌 과제 설명
* OAuth2 네이버 로그인
* 닉네임 변경 기능
* 닉네임 중복 검사 기능
* 회원 탈퇴 기능
## 👩‍💻 요구 사항과 구현 내용
* swagger 작성
* 메일 템플릿 경로 오류 수정
* OAuth2 네이버 로그인
* 닉네임
  * 닉네임 유효성 검사  (닉네임은 한글, 영문, 숫자만 사용할 수 있으며, 2자 이상 10자 이하로 입력해야 합니다.)
  * 닉네임 변경
  * 닉네임 중복 검사
* 회원 탈퇴
  * soft delete (비활성화)
  * 회원 탈퇴 시 자동 로그아웃
* User 필드 수정
  * age, tel 삭제
  * birthDate(생년월일) 추가
  * 생년월일 유효성 검사 (생년월일은 yyyyMMdd 형식의 유효한 날짜여야 합니다.) 
## ✅ PR 포인트 & 궁금한 점
* USER 엔티티가 변경되어 create로 다시 생성해 주셔야 합니다.
* 네이버 로그인 추가로 properties에 추가 사항있습니다.