### PR TITLE
feat: 캘린더 기능 구현

### DIFF
--- a/src/main/java/com/grepp/funfun/app/controller/api/calendar/CalendarApiController.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/calendar/CalendarApiController.java
@@ -1,18 +1,15 @@
 package com.grepp.funfun.app.controller.api.calendar;
 
-import com.grepp.funfun.app.model.calendar.dto.CalendarDTO;
+import com.grepp.funfun.app.controller.api.calendar.payload.CalendarContentRequest;
 import com.grepp.funfun.app.model.calendar.service.CalendarService;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import com.grepp.funfun.infra.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
-import java.util.List;
-import org.springframework.http.HttpStatus;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,43 +17,17 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping(value = "/api/calendars", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequiredArgsConstructor
 public class CalendarApiController {
 
     private final CalendarService calendarService;
 
-    public CalendarApiController(final CalendarService calendarService) {
-        this.calendarService = calendarService;
-    }
-
-    @GetMapping
-    public ResponseEntity<List<CalendarDTO>> getAllCalendars() {
-        return ResponseEntity.ok(calendarService.findAll());
-    }
-
-    @GetMapping("/{id}")
-    public ResponseEntity<CalendarDTO> getCalendar(@PathVariable(name = "id") final Long id) {
-        return ResponseEntity.ok(calendarService.get(id));
-    }
-
     @PostMapping
-    @ApiResponse(responseCode = "201")
-    public ResponseEntity<Long> createCalendar(@RequestBody @Valid final CalendarDTO calendarDTO) {
-        final Long createdId = calendarService.create(calendarDTO);
-        return new ResponseEntity<>(createdId, HttpStatus.CREATED);
+    @Operation(summary = "캘린더 일정 등록", description = "Content 일정 하나를 캘린더에 등록합니다.")
+    public ResponseEntity<ApiResponse<String>> addCalendar(@RequestBody @Valid CalendarContentRequest request,
+        Authentication authentication) {
+        String email = authentication.getName();
+        calendarService.addCalendar(email, request);
+        return ResponseEntity.ok(ApiResponse.success("일정이 성공적으로 등록되었습니다."));
     }
-
-    @PutMapping("/{id}")
-    public ResponseEntity<Long> updateCalendar(@PathVariable(name = "id") final Long id,
-            @RequestBody @Valid final CalendarDTO calendarDTO) {
-        calendarService.update(id, calendarDTO);
-        return ResponseEntity.ok(id);
-    }
-
-    @DeleteMapping("/{id}")
-    @ApiResponse(responseCode = "204")
-    public ResponseEntity<Void> deleteCalendar(@PathVariable(name = "id") final Long id) {
-        calendarService.delete(id);
-        return ResponseEntity.noContent().build();
-    }
-
 }

--- a/src/main/java/com/grepp/funfun/app/controller/api/calendar/CalendarApiController.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/calendar/CalendarApiController.java
@@ -86,4 +86,17 @@ public class CalendarApiController {
         List<CalendarDailyResponse> result = calendarService.getDaily(email, date);
         return ResponseEntity.ok(ApiResponse.success(result));
     }
+
+    @GetMapping("/daily/content")
+    @Operation(summary = "컨텐츠 일별 일정 조회", description = "선택한 날짜로 컨텐츠 일정만 조회합니다.")
+    public ResponseEntity<ApiResponse<List<CalendarDailyResponse>>> getDailyCalendarForContent(
+        @RequestParam int year,
+        @RequestParam int month,
+        @RequestParam int day,
+        Authentication authentication) {
+        String email = authentication.getName();
+        LocalDate date = LocalDate.of(year, month, day);
+        List<CalendarDailyResponse> result = calendarService.getDailyForContent(email, date);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
 }

--- a/src/main/java/com/grepp/funfun/app/controller/api/calendar/CalendarApiController.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/calendar/CalendarApiController.java
@@ -34,21 +34,21 @@ public class CalendarApiController {
     private final CalendarService calendarService;
 
     @PostMapping
-    @Operation(summary = "캘린더 일정 등록", description = "선택한 Content 일정을 캘린더에 등록합니다.")
+    @Operation(summary = "캘린더 일정 등록", description = "선택한 Content 일정을 캘린더에 등록합니다. (Group 타입은 등록 불가)")
     public ResponseEntity<ApiResponse<String>> addCalendar(
         @RequestBody @Valid CalendarContentRequest request,
         Authentication authentication) {
         String email = authentication.getName();
-        calendarService.addCalendar(email, request);
+        calendarService.addContentCalendar(email, request);
         return ResponseEntity.ok(ApiResponse.success("일정이 성공적으로 등록되었습니다."));
     }
 
     @DeleteMapping("/{calendarId}")
-    @Operation(summary = "캘린더 일정 삭제", description = "선택한 Content 일정을 캘린더에서 삭제합니다.")
+    @Operation(summary = "캘린더 일정 삭제", description = "선택한 Content 일정을 캘린더에서 삭제합니다. (Group 타입은 삭제 불가)")
     public ResponseEntity<ApiResponse<String>> deleteCalendar(@PathVariable Long calendarId,
         Authentication authentication) {
         String email = authentication.getName();
-        calendarService.deleteCalendar(calendarId, email);
+        calendarService.deleteContentCalendar(calendarId, email);
         return ResponseEntity.ok(ApiResponse.success("일정이 성공적으로 삭제되었습니다."));
     }
 
@@ -58,7 +58,7 @@ public class CalendarApiController {
         @RequestBody @Valid CalendarUpdateRequest request,
         Authentication authentication) {
         String email = authentication.getName();
-        calendarService.updateCalendar(calendarId, request.getSelectedDate(), email);
+        calendarService.updateContentCalendar(calendarId, request.getSelectedDate(), email);
         return ResponseEntity.ok(ApiResponse.success("일정이 성공적으로 수정되었습니다."));
     }
 

--- a/src/main/java/com/grepp/funfun/app/controller/api/calendar/CalendarApiController.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/calendar/CalendarApiController.java
@@ -34,7 +34,7 @@ public class CalendarApiController {
     private final CalendarService calendarService;
 
     @PostMapping
-    @Operation(summary = "캘린더 일정 등록", description = "선택한 Content 일정을 캘린더에 등록합니다.")
+    @Operation(summary = "캘린더 일정 등록", description = "선택한 컨텐츠 일정을 캘린더에 등록합니다.")
     public ResponseEntity<ApiResponse<String>> addCalendar(
         @RequestBody @Valid CalendarContentRequest request,
         Authentication authentication) {
@@ -44,7 +44,7 @@ public class CalendarApiController {
     }
 
     @DeleteMapping("/{calendarId}")
-    @Operation(summary = "캘린더 일정 삭제", description = "선택한 Content 일정을 캘린더에서 삭제합니다.")
+    @Operation(summary = "캘린더 일정 삭제", description = "선택한 컨텐츠 일정을 캘린더에서 삭제합니다.")
     public ResponseEntity<ApiResponse<String>> deleteCalendar(@PathVariable Long calendarId,
         Authentication authentication) {
         String email = authentication.getName();
@@ -53,7 +53,7 @@ public class CalendarApiController {
     }
 
     @PatchMapping("/{calendarId}")
-    @Operation(summary = "캘린더 일정 수정", description = "선택한 Content 일정을 수정합니다.")
+    @Operation(summary = "캘린더 일정 수정", description = "선택한 컨텐츠 일정을 수정합니다.")
     public ResponseEntity<ApiResponse<String>> updateCalendar(@PathVariable Long calendarId,
         @RequestBody @Valid CalendarUpdateRequest request,
         Authentication authentication) {

--- a/src/main/java/com/grepp/funfun/app/controller/api/calendar/CalendarApiController.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/calendar/CalendarApiController.java
@@ -34,7 +34,7 @@ public class CalendarApiController {
     private final CalendarService calendarService;
 
     @PostMapping
-    @Operation(summary = "캘린더 일정 등록", description = "선택한 Content 일정을 캘린더에 등록합니다. (Group 타입은 등록 불가)")
+    @Operation(summary = "캘린더 일정 등록", description = "선택한 Content 일정을 캘린더에 등록합니다.")
     public ResponseEntity<ApiResponse<String>> addCalendar(
         @RequestBody @Valid CalendarContentRequest request,
         Authentication authentication) {
@@ -44,7 +44,7 @@ public class CalendarApiController {
     }
 
     @DeleteMapping("/{calendarId}")
-    @Operation(summary = "캘린더 일정 삭제", description = "선택한 Content 일정을 캘린더에서 삭제합니다. (Group 타입은 삭제 불가)")
+    @Operation(summary = "캘린더 일정 삭제", description = "선택한 Content 일정을 캘린더에서 삭제합니다.")
     public ResponseEntity<ApiResponse<String>> deleteCalendar(@PathVariable Long calendarId,
         Authentication authentication) {
         String email = authentication.getName();
@@ -53,7 +53,7 @@ public class CalendarApiController {
     }
 
     @PatchMapping("/{calendarId}")
-    @Operation(summary = "캘린더 일정 수정", description = "선택한 Content 일정을 수정합니다. (Group 타입은 수정 불가)")
+    @Operation(summary = "캘린더 일정 수정", description = "선택한 Content 일정을 수정합니다.")
     public ResponseEntity<ApiResponse<String>> updateCalendar(@PathVariable Long calendarId,
         @RequestBody @Valid CalendarUpdateRequest request,
         Authentication authentication) {

--- a/src/main/java/com/grepp/funfun/app/controller/api/calendar/CalendarApiController.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/calendar/CalendarApiController.java
@@ -9,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,11 +25,20 @@ public class CalendarApiController {
     private final CalendarService calendarService;
 
     @PostMapping
-    @Operation(summary = "캘린더 일정 등록", description = "Content 일정 하나를 캘린더에 등록합니다.")
+    @Operation(summary = "캘린더 일정 등록", description = "선택한 Content 일정을 캘린더에 등록합니다.")
     public ResponseEntity<ApiResponse<String>> addCalendar(@RequestBody @Valid CalendarContentRequest request,
         Authentication authentication) {
         String email = authentication.getName();
         calendarService.addCalendar(email, request);
         return ResponseEntity.ok(ApiResponse.success("일정이 성공적으로 등록되었습니다."));
+    }
+
+    @DeleteMapping("/{calendarId}")
+    @Operation(summary = "캘린더 일정 삭제", description = "선택한 Content 일정을 캘린더에서 삭제합니다.")
+    public ResponseEntity<ApiResponse<String>> deleteCalendar(@PathVariable Long calendarId,
+        Authentication authentication) {
+        String email = authentication.getName();
+        calendarService.deleteCalendar(calendarId, email);
+        return ResponseEntity.ok(ApiResponse.success("일정이 성공적으로 삭제되었습니다."));
     }
 }

--- a/src/main/java/com/grepp/funfun/app/controller/api/calendar/CalendarApiController.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/calendar/CalendarApiController.java
@@ -1,21 +1,26 @@
 package com.grepp.funfun.app.controller.api.calendar;
 
 import com.grepp.funfun.app.controller.api.calendar.payload.CalendarContentRequest;
+import com.grepp.funfun.app.controller.api.calendar.payload.CalendarMonthlyResponse;
 import com.grepp.funfun.app.controller.api.calendar.payload.CalendarUpdateRequest;
 import com.grepp.funfun.app.model.calendar.service.CalendarService;
 import com.grepp.funfun.infra.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
+import java.time.YearMonth;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 
@@ -52,5 +57,16 @@ public class CalendarApiController {
         String email = authentication.getName();
         calendarService.updateCalendar(calendarId, request.getSelectedDate(), email);
         return ResponseEntity.ok(ApiResponse.success("일정이 성공적으로 수정되었습니다."));
+    }
+
+    @GetMapping("/monthly")
+    @Operation(summary = "월별 일정 조회", description = "선택한 년도와 월에 해당하는 모든 일정을 조회합니다.")
+    public ResponseEntity<ApiResponse<List<CalendarMonthlyResponse>>> getMonthlyCalendar(@RequestParam int year,
+        @RequestParam int month,
+        Authentication authentication) {
+        String email = authentication.getName();
+        YearMonth yearMonth = YearMonth.of(year, month);
+        List<CalendarMonthlyResponse> result = calendarService.getMonthly(email, yearMonth);
+        return ResponseEntity.ok(ApiResponse.success(result));
     }
 }

--- a/src/main/java/com/grepp/funfun/app/controller/api/calendar/CalendarApiController.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/calendar/CalendarApiController.java
@@ -1,12 +1,14 @@
 package com.grepp.funfun.app.controller.api.calendar;
 
 import com.grepp.funfun.app.controller.api.calendar.payload.CalendarContentRequest;
+import com.grepp.funfun.app.controller.api.calendar.payload.CalendarDailyResponse;
 import com.grepp.funfun.app.controller.api.calendar.payload.CalendarMonthlyResponse;
 import com.grepp.funfun.app.controller.api.calendar.payload.CalendarUpdateRequest;
 import com.grepp.funfun.app.model.calendar.service.CalendarService;
 import com.grepp.funfun.infra.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
+import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -33,7 +35,8 @@ public class CalendarApiController {
 
     @PostMapping
     @Operation(summary = "캘린더 일정 등록", description = "선택한 Content 일정을 캘린더에 등록합니다.")
-    public ResponseEntity<ApiResponse<String>> addCalendar(@RequestBody @Valid CalendarContentRequest request,
+    public ResponseEntity<ApiResponse<String>> addCalendar(
+        @RequestBody @Valid CalendarContentRequest request,
         Authentication authentication) {
         String email = authentication.getName();
         calendarService.addCalendar(email, request);
@@ -61,12 +64,26 @@ public class CalendarApiController {
 
     @GetMapping("/monthly")
     @Operation(summary = "월별 일정 조회", description = "선택한 년도와 월에 해당하는 모든 일정을 조회합니다.")
-    public ResponseEntity<ApiResponse<List<CalendarMonthlyResponse>>> getMonthlyCalendar(@RequestParam int year,
+    public ResponseEntity<ApiResponse<List<CalendarMonthlyResponse>>> getMonthlyCalendar(
+        @RequestParam int year,
         @RequestParam int month,
         Authentication authentication) {
         String email = authentication.getName();
         YearMonth yearMonth = YearMonth.of(year, month);
         List<CalendarMonthlyResponse> result = calendarService.getMonthly(email, yearMonth);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @GetMapping("/daily")
+    @Operation(summary = "일별 일정 조회", description = "선택한 날짜로 일정을 조회합니다.")
+    public ResponseEntity<ApiResponse<List<CalendarDailyResponse>>> getDailyCalendar(
+        @RequestParam int year,
+        @RequestParam int month,
+        @RequestParam int day,
+        Authentication authentication) {
+        String email = authentication.getName();
+        LocalDate date = LocalDate.of(year, month, day);
+        List<CalendarDailyResponse> result = calendarService.getDaily(email, date);
         return ResponseEntity.ok(ApiResponse.success(result));
     }
 }

--- a/src/main/java/com/grepp/funfun/app/controller/api/calendar/CalendarApiController.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/calendar/CalendarApiController.java
@@ -1,6 +1,7 @@
 package com.grepp.funfun.app.controller.api.calendar;
 
 import com.grepp.funfun.app.controller.api.calendar.payload.CalendarContentRequest;
+import com.grepp.funfun.app.controller.api.calendar.payload.CalendarUpdateRequest;
 import com.grepp.funfun.app.model.calendar.service.CalendarService;
 import com.grepp.funfun.infra.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,6 +11,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -40,5 +42,15 @@ public class CalendarApiController {
         String email = authentication.getName();
         calendarService.deleteCalendar(calendarId, email);
         return ResponseEntity.ok(ApiResponse.success("일정이 성공적으로 삭제되었습니다."));
+    }
+
+    @PatchMapping("/{calendarId}")
+    @Operation(summary = "캘린더 일정 수정", description = "선택한 Content 일정을 수정합니다. (Group 타입은 수정 불가)")
+    public ResponseEntity<ApiResponse<String>> updateCalendar(@PathVariable Long calendarId,
+        @RequestBody @Valid CalendarUpdateRequest request,
+        Authentication authentication) {
+        String email = authentication.getName();
+        calendarService.updateCalendar(calendarId, request.getSelectedDate(), email);
+        return ResponseEntity.ok(ApiResponse.success("일정이 성공적으로 수정되었습니다."));
     }
 }

--- a/src/main/java/com/grepp/funfun/app/controller/api/calendar/payload/CalendarContentRequest.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/calendar/payload/CalendarContentRequest.java
@@ -1,0 +1,23 @@
+package com.grepp.funfun.app.controller.api.calendar.payload;
+
+import com.grepp.funfun.app.model.calendar.code.ActivityType;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import lombok.Data;
+
+@Data
+public class CalendarContentRequest {
+    @NotNull
+    private ActivityType type;
+
+    @AssertTrue(message = "이 요청은 ActivityType이 CONTENT인 경우에만 허용됩니다.")
+    public boolean isType() {
+        return this.type == ActivityType.CONTENT;
+    }
+
+    @NotNull
+    private Long activityId;
+    @NotNull
+    private LocalDateTime selectedDate;
+}

--- a/src/main/java/com/grepp/funfun/app/controller/api/calendar/payload/CalendarContentRequest.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/calendar/payload/CalendarContentRequest.java
@@ -1,21 +1,11 @@
 package com.grepp.funfun.app.controller.api.calendar.payload;
 
-import com.grepp.funfun.app.model.calendar.code.ActivityType;
-import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import lombok.Data;
 
 @Data
 public class CalendarContentRequest {
-    @NotNull
-    private ActivityType type;
-
-    @AssertTrue(message = "이 요청은 ActivityType이 CONTENT인 경우에만 허용됩니다.")
-    public boolean isType() {
-        return this.type == ActivityType.CONTENT;
-    }
-
     @NotNull
     private Long activityId;
     @NotNull

--- a/src/main/java/com/grepp/funfun/app/controller/api/calendar/payload/CalendarDailyResponse.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/calendar/payload/CalendarDailyResponse.java
@@ -10,6 +10,7 @@ import lombok.Data;
 public class CalendarDailyResponse {
     private Long calendarId;
     private ActivityType type;
+    private Long activityId;
     private String title;
     private LocalDateTime selectedDate;
     private String address;

--- a/src/main/java/com/grepp/funfun/app/controller/api/calendar/payload/CalendarDailyResponse.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/calendar/payload/CalendarDailyResponse.java
@@ -1,0 +1,16 @@
+package com.grepp.funfun.app.controller.api.calendar.payload;
+
+import com.grepp.funfun.app.model.calendar.code.ActivityType;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class CalendarDailyResponse {
+    private Long calendarId;
+    private ActivityType type;
+    private String title;
+    private LocalDateTime selectedDate;
+    private String address;
+}

--- a/src/main/java/com/grepp/funfun/app/controller/api/calendar/payload/CalendarMonthlyResponse.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/calendar/payload/CalendarMonthlyResponse.java
@@ -1,0 +1,15 @@
+package com.grepp.funfun.app.controller.api.calendar.payload;
+
+import com.grepp.funfun.app.model.calendar.code.ActivityType;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class CalendarMonthlyResponse {
+    private Long calendarId;
+    private ActivityType type;
+    private String title;
+    private LocalDateTime selectedDate;
+}

--- a/src/main/java/com/grepp/funfun/app/controller/api/calendar/payload/CalendarMonthlyResponse.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/calendar/payload/CalendarMonthlyResponse.java
@@ -10,6 +10,7 @@ import lombok.Data;
 public class CalendarMonthlyResponse {
     private Long calendarId;
     private ActivityType type;
+    private Long activityId;
     private String title;
     private LocalDateTime selectedDate;
 }

--- a/src/main/java/com/grepp/funfun/app/controller/api/calendar/payload/CalendarUpdateRequest.java
+++ b/src/main/java/com/grepp/funfun/app/controller/api/calendar/payload/CalendarUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.grepp.funfun.app.controller.api.calendar.payload;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import lombok.Data;
+
+@Data
+public class CalendarUpdateRequest {
+    @NotNull
+    private LocalDateTime selectedDate;
+}

--- a/src/main/java/com/grepp/funfun/app/model/calendar/repository/CalendarRepository.java
+++ b/src/main/java/com/grepp/funfun/app/model/calendar/repository/CalendarRepository.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 
-public interface CalendarRepository extends JpaRepository<Calendar, Long> {
+public interface CalendarRepository extends JpaRepository<Calendar, Long>, CalendarRepositoryCustom {
 
     Calendar findFirstByContent(Content content);
 

--- a/src/main/java/com/grepp/funfun/app/model/calendar/repository/CalendarRepository.java
+++ b/src/main/java/com/grepp/funfun/app/model/calendar/repository/CalendarRepository.java
@@ -14,4 +14,8 @@ public interface CalendarRepository extends JpaRepository<Calendar, Long>, Calen
     Calendar findFirstByGroup(Group group);
 
     Optional<Calendar> findByIdAndEmail(Long id, String email);
+
+    void deleteByGroupId(Long groupId);
+
+    void deleteByEmailAndGroupId(String email, Long groupId);
 }

--- a/src/main/java/com/grepp/funfun/app/model/calendar/repository/CalendarRepository.java
+++ b/src/main/java/com/grepp/funfun/app/model/calendar/repository/CalendarRepository.java
@@ -3,6 +3,7 @@ package com.grepp.funfun.app.model.calendar.repository;
 import com.grepp.funfun.app.model.calendar.entity.Calendar;
 import com.grepp.funfun.app.model.content.entity.Content;
 import com.grepp.funfun.app.model.group.entity.Group;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 
@@ -12,4 +13,5 @@ public interface CalendarRepository extends JpaRepository<Calendar, Long> {
 
     Calendar findFirstByGroup(Group group);
 
+    Optional<Calendar> findByIdAndEmail(Long id, String email);
 }

--- a/src/main/java/com/grepp/funfun/app/model/calendar/repository/CalendarRepositoryCustom.java
+++ b/src/main/java/com/grepp/funfun/app/model/calendar/repository/CalendarRepositoryCustom.java
@@ -1,5 +1,6 @@
 package com.grepp.funfun.app.model.calendar.repository;
 
+import com.grepp.funfun.app.controller.api.calendar.payload.CalendarDailyResponse;
 import com.grepp.funfun.app.controller.api.calendar.payload.CalendarMonthlyResponse;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -9,4 +10,6 @@ import org.springframework.stereotype.Repository;
 public interface CalendarRepositoryCustom {
     List<CalendarMonthlyResponse> findMonthlyContentCalendars(String email, LocalDateTime start, LocalDateTime end);
     List<CalendarMonthlyResponse> findMonthlyGroupCalendars(String email, LocalDateTime start, LocalDateTime end);
+    List<CalendarDailyResponse> findDailyContentCalendars(String email, LocalDateTime start, LocalDateTime end);
+    List<CalendarDailyResponse> findDailyGroupCalendars(String email, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/grepp/funfun/app/model/calendar/repository/CalendarRepositoryCustom.java
+++ b/src/main/java/com/grepp/funfun/app/model/calendar/repository/CalendarRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.grepp.funfun.app.model.calendar.repository;
+
+import com.grepp.funfun.app.controller.api.calendar.payload.CalendarMonthlyResponse;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CalendarRepositoryCustom {
+    List<CalendarMonthlyResponse> findMonthlyContentCalendars(String email, LocalDateTime start, LocalDateTime end);
+    List<CalendarMonthlyResponse> findMonthlyGroupCalendars(String email, LocalDateTime start, LocalDateTime end);
+}

--- a/src/main/java/com/grepp/funfun/app/model/calendar/repository/CalendarRepositoryCustomImpl.java
+++ b/src/main/java/com/grepp/funfun/app/model/calendar/repository/CalendarRepositoryCustomImpl.java
@@ -1,0 +1,59 @@
+package com.grepp.funfun.app.model.calendar.repository;
+
+import com.grepp.funfun.app.controller.api.calendar.payload.CalendarMonthlyResponse;
+import com.grepp.funfun.app.model.calendar.code.ActivityType;
+import com.grepp.funfun.app.model.calendar.entity.QCalendar;
+import com.grepp.funfun.app.model.content.entity.QContent;
+import com.grepp.funfun.app.model.group.entity.QGroup;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CalendarRepositoryCustomImpl implements CalendarRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+    private final QCalendar calendar = QCalendar.calendar;
+    private final QContent content = QContent.content;
+    private final QGroup group = QGroup.group;
+
+    @Override
+    public List<CalendarMonthlyResponse> findMonthlyContentCalendars(String email, LocalDateTime start,
+        LocalDateTime end) {
+        return queryFactory
+            .select(Projections.constructor(
+                CalendarMonthlyResponse.class,
+                calendar.id,
+                calendar.type,
+                content.contentTitle,
+                calendar.selectedDate
+            ))
+            .from(calendar)
+            .join(calendar.content, content)
+            .where(calendar.email.eq(email),
+                calendar.type.eq(ActivityType.CONTENT),
+                calendar.selectedDate.between(start, end))
+            .fetch();
+    }
+
+    @Override
+    public List<CalendarMonthlyResponse> findMonthlyGroupCalendars(String email, LocalDateTime start,
+        LocalDateTime end) {
+        return queryFactory
+            .select(Projections.constructor(
+                CalendarMonthlyResponse.class,
+                calendar.id,
+                calendar.type,
+                group.title,
+                group.groupDate
+            ))
+            .from(calendar)
+            .join(calendar.group, group)
+            .where(calendar.email.eq(email),
+                calendar.type.eq(ActivityType.GROUP),
+                group.groupDate.between(start, end))
+            .fetch();
+    }
+}

--- a/src/main/java/com/grepp/funfun/app/model/calendar/repository/CalendarRepositoryCustomImpl.java
+++ b/src/main/java/com/grepp/funfun/app/model/calendar/repository/CalendarRepositoryCustomImpl.java
@@ -1,5 +1,6 @@
 package com.grepp.funfun.app.model.calendar.repository;
 
+import com.grepp.funfun.app.controller.api.calendar.payload.CalendarDailyResponse;
 import com.grepp.funfun.app.controller.api.calendar.payload.CalendarMonthlyResponse;
 import com.grepp.funfun.app.model.calendar.code.ActivityType;
 import com.grepp.funfun.app.model.calendar.entity.QCalendar;
@@ -48,6 +49,46 @@ public class CalendarRepositoryCustomImpl implements CalendarRepositoryCustom{
                 calendar.type,
                 group.title,
                 group.groupDate
+            ))
+            .from(calendar)
+            .join(calendar.group, group)
+            .where(calendar.email.eq(email),
+                calendar.type.eq(ActivityType.GROUP),
+                group.groupDate.between(start, end))
+            .fetch();
+    }
+
+    @Override
+    public List<CalendarDailyResponse> findDailyContentCalendars(String email, LocalDateTime start,
+        LocalDateTime end) {
+        return queryFactory
+            .select(Projections.constructor(
+                CalendarDailyResponse.class,
+                calendar.id,
+                calendar.type,
+                content.contentTitle,
+                calendar.selectedDate,
+                content.address
+            ))
+            .from(calendar)
+            .join(calendar.content, content)
+            .where(calendar.email.eq(email),
+                calendar.type.eq(ActivityType.CONTENT),
+                calendar.selectedDate.between(start, end))
+            .fetch();
+    }
+
+    @Override
+    public List<CalendarDailyResponse> findDailyGroupCalendars(String email, LocalDateTime start,
+        LocalDateTime end) {
+        return queryFactory
+            .select(Projections.constructor(
+                CalendarDailyResponse.class,
+                calendar.id,
+                calendar.type,
+                group.title,
+                group.groupDate,
+                group.address
             ))
             .from(calendar)
             .join(calendar.group, group)

--- a/src/main/java/com/grepp/funfun/app/model/calendar/repository/CalendarRepositoryCustomImpl.java
+++ b/src/main/java/com/grepp/funfun/app/model/calendar/repository/CalendarRepositoryCustomImpl.java
@@ -28,6 +28,7 @@ public class CalendarRepositoryCustomImpl implements CalendarRepositoryCustom{
                 CalendarMonthlyResponse.class,
                 calendar.id,
                 calendar.type,
+                content.id,
                 content.contentTitle,
                 calendar.selectedDate
             ))
@@ -47,6 +48,7 @@ public class CalendarRepositoryCustomImpl implements CalendarRepositoryCustom{
                 CalendarMonthlyResponse.class,
                 calendar.id,
                 calendar.type,
+                group.id,
                 group.title,
                 group.groupDate
             ))
@@ -66,6 +68,7 @@ public class CalendarRepositoryCustomImpl implements CalendarRepositoryCustom{
                 CalendarDailyResponse.class,
                 calendar.id,
                 calendar.type,
+                content.id,
                 content.contentTitle,
                 calendar.selectedDate,
                 content.address
@@ -86,6 +89,7 @@ public class CalendarRepositoryCustomImpl implements CalendarRepositoryCustom{
                 CalendarDailyResponse.class,
                 calendar.id,
                 calendar.type,
+                group.id,
                 group.title,
                 group.groupDate,
                 group.address

--- a/src/main/java/com/grepp/funfun/app/model/calendar/service/CalendarService.java
+++ b/src/main/java/com/grepp/funfun/app/model/calendar/service/CalendarService.java
@@ -47,6 +47,18 @@ public class CalendarService {
         calendarRepository.save(calendar);
     }
 
+    @Transactional
+    public void deleteCalendar(Long calendarId, String email) {
+        Calendar calendar = calendarRepository.findByIdAndEmail(calendarId, email)
+            .orElseThrow(() -> new CommonException(ResponseCode.NOT_FOUND));
+
+        if(calendar.getType() == ActivityType.GROUP) {
+            throw new CommonException(ResponseCode.BAD_REQUEST);
+        }
+
+        calendarRepository.delete(calendar);
+    }
+
     public List<CalendarDTO> findAll() {
         final List<Calendar> calendars = calendarRepository.findAll(Sort.by("id"));
         return calendars.stream()

--- a/src/main/java/com/grepp/funfun/app/model/calendar/service/CalendarService.java
+++ b/src/main/java/com/grepp/funfun/app/model/calendar/service/CalendarService.java
@@ -1,6 +1,7 @@
 package com.grepp.funfun.app.model.calendar.service;
 
 import com.grepp.funfun.app.controller.api.calendar.payload.CalendarContentRequest;
+import com.grepp.funfun.app.controller.api.calendar.payload.CalendarMonthlyResponse;
 import com.grepp.funfun.app.model.calendar.code.ActivityType;
 import com.grepp.funfun.app.model.calendar.dto.CalendarDTO;
 import com.grepp.funfun.app.model.calendar.entity.Calendar;
@@ -12,6 +13,9 @@ import com.grepp.funfun.app.model.group.repository.GroupRepository;
 import com.grepp.funfun.infra.error.exceptions.CommonException;
 import com.grepp.funfun.infra.response.ResponseCode;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.YearMonth;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
@@ -70,6 +74,20 @@ public class CalendarService {
         }
 
         calendar.setSelectedDate(selectedDate);
+    }
+
+    public List<CalendarMonthlyResponse> getMonthly(String email, YearMonth month) {
+        LocalDateTime start = month.atDay(1).atStartOfDay();
+        LocalDateTime end = month.atEndOfMonth().atTime(LocalTime.MAX);
+
+        List<CalendarMonthlyResponse> contentList = calendarRepository.findMonthlyContentCalendars(email, start, end);
+        List<CalendarMonthlyResponse> groupList = calendarRepository.findMonthlyGroupCalendars(email, start, end);
+
+        List<CalendarMonthlyResponse> result = new ArrayList<>();
+        result.addAll(contentList);
+        result.addAll(groupList);
+
+        return result;
     }
 
     public List<CalendarDTO> findAll() {

--- a/src/main/java/com/grepp/funfun/app/model/calendar/service/CalendarService.java
+++ b/src/main/java/com/grepp/funfun/app/model/calendar/service/CalendarService.java
@@ -1,6 +1,7 @@
 package com.grepp.funfun.app.model.calendar.service;
 
 import com.grepp.funfun.app.controller.api.calendar.payload.CalendarContentRequest;
+import com.grepp.funfun.app.controller.api.calendar.payload.CalendarDailyResponse;
 import com.grepp.funfun.app.controller.api.calendar.payload.CalendarMonthlyResponse;
 import com.grepp.funfun.app.model.calendar.code.ActivityType;
 import com.grepp.funfun.app.model.calendar.dto.CalendarDTO;
@@ -12,10 +13,12 @@ import com.grepp.funfun.app.model.group.entity.Group;
 import com.grepp.funfun.app.model.group.repository.GroupRepository;
 import com.grepp.funfun.infra.error.exceptions.CommonException;
 import com.grepp.funfun.infra.response.ResponseCode;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.YearMonth;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
@@ -86,6 +89,22 @@ public class CalendarService {
         List<CalendarMonthlyResponse> result = new ArrayList<>();
         result.addAll(contentList);
         result.addAll(groupList);
+
+        return result;
+    }
+
+    public List<CalendarDailyResponse> getDaily(String email, LocalDate date) {
+        LocalDateTime start = date.atStartOfDay();
+        LocalDateTime end = start.plusDays(1).minusNanos(1);
+
+        List<CalendarDailyResponse> content = calendarRepository.findDailyContentCalendars(email, start, end);
+        List<CalendarDailyResponse> group = calendarRepository.findDailyGroupCalendars(email, start, end);
+
+        List<CalendarDailyResponse> result = new ArrayList<>();
+        result.addAll(content);
+        result.addAll(group);
+        // 오름차순 정렬
+        result.sort(Comparator.comparing(CalendarDailyResponse::getSelectedDate));
 
         return result;
     }

--- a/src/main/java/com/grepp/funfun/app/model/calendar/service/CalendarService.java
+++ b/src/main/java/com/grepp/funfun/app/model/calendar/service/CalendarService.java
@@ -11,6 +11,7 @@ import com.grepp.funfun.app.model.group.entity.Group;
 import com.grepp.funfun.app.model.group.repository.GroupRepository;
 import com.grepp.funfun.infra.error.exceptions.CommonException;
 import com.grepp.funfun.infra.response.ResponseCode;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
@@ -57,6 +58,18 @@ public class CalendarService {
         }
 
         calendarRepository.delete(calendar);
+    }
+
+    @Transactional
+    public void updateCalendar(Long calendarId, LocalDateTime selectedDate, String email) {
+        Calendar calendar = calendarRepository.findByIdAndEmail(calendarId, email)
+            .orElseThrow(() -> new CommonException(ResponseCode.NOT_FOUND));
+
+        if (calendar.getType() == ActivityType.GROUP) {
+            throw new CommonException(ResponseCode.BAD_REQUEST);
+        }
+
+        calendar.setSelectedDate(selectedDate);
     }
 
     public List<CalendarDTO> findAll() {

--- a/src/main/java/com/grepp/funfun/app/model/calendar/service/CalendarService.java
+++ b/src/main/java/com/grepp/funfun/app/model/calendar/service/CalendarService.java
@@ -106,6 +106,13 @@ public class CalendarService {
         return result;
     }
 
+    public List<CalendarDailyResponse> getDailyForContent(String email, LocalDate date) {
+        LocalDateTime start = date.atStartOfDay();
+        LocalDateTime end = start.plusDays(1).minusNanos(1);
+
+        return calendarRepository.findDailyContentCalendars(email, start, end);
+    }
+
     @Transactional
     public void addGroupCalendar(String email, Group group) {
         Calendar calendar = new Calendar();

--- a/src/main/java/com/grepp/funfun/app/model/calendar/service/CalendarService.java
+++ b/src/main/java/com/grepp/funfun/app/model/calendar/service/CalendarService.java
@@ -38,11 +38,7 @@ public class CalendarService {
     public void addContentCalendar(String email, CalendarContentRequest request) {
         Calendar calendar = new Calendar();
         calendar.setEmail(email);
-        calendar.setType(request.getType());
-
-        if(calendar.getType() == ActivityType.GROUP) {
-            throw new CommonException(ResponseCode.BAD_REQUEST);
-        }
+        calendar.setType(ActivityType.CONTENT);
 
         Content content = contentRepository.findById(request.getActivityId())
             .orElseThrow(() -> new CommonException(ResponseCode.NOT_FOUND));

--- a/src/main/java/com/grepp/funfun/app/model/group/service/GroupService.java
+++ b/src/main/java/com/grepp/funfun/app/model/group/service/GroupService.java
@@ -7,6 +7,7 @@ import com.grepp.funfun.app.model.bookmark.entity.GroupBookmark;
 import com.grepp.funfun.app.model.bookmark.repository.GroupBookmarkRepository;
 import com.grepp.funfun.app.model.calendar.entity.Calendar;
 import com.grepp.funfun.app.model.calendar.repository.CalendarRepository;
+import com.grepp.funfun.app.model.calendar.service.CalendarService;
 import com.grepp.funfun.app.model.chat.entity.ChatRoom;
 import com.grepp.funfun.app.model.chat.repository.ChatRoomRepository;
 import com.grepp.funfun.app.model.group.code.GroupStatus;
@@ -46,7 +47,7 @@ public class GroupService {
     private final ChatRoomRepository chatRoomRepository;
     private final CalendarRepository calendarRepository;
     private final GroupHashtagRepository groupHashtagRepository;
-
+    private final CalendarService calendarService;
 
     public List<GroupDTO> findAll() {
         final List<Group> groups = groupRepository.findAll(Sort.by("id"));
@@ -113,6 +114,9 @@ public class GroupService {
         chatRoom.setGroup(savedGroup);
         chatRoom.setName(savedGroup.getId() + "번 채팅방");
         chatRoomRepository.save(chatRoom);
+
+        // 모임 생성 시 리더의 캘린더에 자동으로 일정 추가하기
+        calendarService.addGroupCalendar(leaderEmail, savedGroup);
     }
 
 
@@ -158,8 +162,10 @@ public class GroupService {
         for (Participant participant : group.getParticipants()) {
             participant.unActivated();
             participant.setStatus(ParticipantStatus.GROUP_DELETED);
-
         }
+
+        // 해당 모임 id 의 일정들 삭제
+        calendarService.deleteGroupCalendar(groupId);
     }
 
     //모임 취소
@@ -175,8 +181,10 @@ public class GroupService {
         for (Participant participant : group.getParticipants()) {
             participant.unActivated();
             participant.setStatus(ParticipantStatus.GROUP_CANCELED);
-
         }
+
+        // 해당 모임 id 의 일정들 삭제
+        calendarService.deleteGroupCalendar(groupId);
     }
 
     // 모임 완료

--- a/src/test/java/com/grepp/funfun/app/model/calendar/service/CalendarServiceTest.java
+++ b/src/test/java/com/grepp/funfun/app/model/calendar/service/CalendarServiceTest.java
@@ -1,0 +1,265 @@
+package com.grepp.funfun.app.model.calendar.service;
+
+import com.grepp.funfun.app.controller.api.calendar.payload.CalendarContentRequest;
+import com.grepp.funfun.app.controller.api.calendar.payload.CalendarDailyResponse;
+import com.grepp.funfun.app.controller.api.calendar.payload.CalendarMonthlyResponse;
+import com.grepp.funfun.app.model.calendar.code.ActivityType;
+import com.grepp.funfun.app.model.calendar.entity.Calendar;
+import com.grepp.funfun.app.model.calendar.repository.CalendarRepository;
+import com.grepp.funfun.app.model.content.entity.Content;
+import com.grepp.funfun.app.model.content.repository.ContentRepository;
+import com.grepp.funfun.app.model.group.entity.Group;
+import com.grepp.funfun.infra.error.exceptions.CommonException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CalendarServiceTest {
+
+    @InjectMocks
+    private CalendarService calendarService;
+
+    @Mock
+    private CalendarRepository calendarRepository;
+
+    @Mock
+    private ContentRepository contentRepository;
+
+    private String email;
+    private Long calendarId;
+    private Calendar calendar;
+
+    @BeforeEach
+    void setUp() {
+        email = "user@example.com";
+        calendarId = 1L;
+        calendar = new Calendar();
+    }
+
+    @Test
+    void addContentCalendar_정상() {
+        // given
+        Long contentId = 1L;
+        LocalDateTime selectedDate = LocalDateTime.of(2025, 7, 8, 10, 0);
+        Content content = new Content();
+        CalendarContentRequest request = new CalendarContentRequest();
+        request.setActivityId(contentId);
+        request.setSelectedDate(selectedDate);
+
+        // when
+        when(contentRepository.findById(contentId)).thenReturn(Optional.of(content));
+        calendarService.addContentCalendar(email, request);
+
+        // then
+        verify(calendarRepository).save(any(Calendar.class));
+    }
+
+    @Test
+    void addContentCalendar_NOT_FOUND_예외() {
+        // given
+        Long contentId = 1L;
+        LocalDateTime selectedDate = LocalDateTime.of(2025, 7, 8, 10, 0);
+        CalendarContentRequest request = new CalendarContentRequest();
+        request.setActivityId(contentId);
+        request.setSelectedDate(selectedDate);
+
+        // when, then
+        when(contentRepository.findById(contentId)).thenReturn(Optional.empty());
+        assertThrows(CommonException.class, () -> calendarService.addContentCalendar(email, request));
+    }
+
+    @Test
+    void deleteContentCalendar_정상() {
+        // given
+        calendar.setType(ActivityType.CONTENT);
+
+        // when
+        when(calendarRepository.findByIdAndEmail(calendarId, email)).thenReturn(Optional.of(calendar));
+        calendarService.deleteContentCalendar(calendarId, email);
+
+        // then
+        verify(calendarRepository).delete(calendar);
+    }
+
+    @Test
+    void deleteContentCalendar_모임타입_예외() {
+        // given
+        // GROUP 일 때
+        calendar.setType(ActivityType.GROUP);
+
+        // when, then
+        when(calendarRepository.findByIdAndEmail(calendarId, email)).thenReturn(Optional.of(calendar));
+        assertThrows(CommonException.class, () -> calendarService.deleteContentCalendar(calendarId, email));
+    }
+
+    @Test
+    void deleteContentCalendar_NOT_FOUND_예외() {
+        // given
+        calendar.setType(ActivityType.CONTENT);
+
+        // when, then
+        when(calendarRepository.findByIdAndEmail(calendarId, email)).thenReturn(Optional.empty());
+        assertThrows(CommonException.class, () -> calendarService.deleteContentCalendar(calendarId, email));
+    }
+
+    @Test
+    void updateContentCalendar_정상() {
+        // given
+        LocalDateTime newDate = LocalDateTime.of(2025, 7, 8, 12, 0);
+        calendar.setType(ActivityType.CONTENT);
+
+        // when
+        when(calendarRepository.findByIdAndEmail(calendarId, email)).thenReturn(Optional.of(calendar));
+        calendarService.updateContentCalendar(calendarId, newDate, email);
+
+        // then
+        assertEquals(newDate, calendar.getSelectedDate());
+    }
+
+    @Test
+    void updateContentCalendar_모임타입_예외() {
+        // given
+        LocalDateTime newDate = LocalDateTime.of(2025, 7, 8, 12, 0);
+        // GROUP 일 때
+        calendar.setType(ActivityType.GROUP);
+
+        // when, then
+        when(calendarRepository.findByIdAndEmail(calendarId, email)).thenReturn(Optional.of(calendar));
+        assertThrows(CommonException.class, () -> calendarService.updateContentCalendar(calendarId, newDate, email));
+    }
+
+    @Test
+    void updateContentCalendar_NOT_FOUND_예외() {
+        // given
+        LocalDateTime newDate = LocalDateTime.of(2025, 7, 8, 12, 0);
+        calendar.setType(ActivityType.CONTENT);
+
+        // when, then
+        when(calendarRepository.findByIdAndEmail(calendarId, email)).thenReturn(Optional.empty());
+        assertThrows(CommonException.class, () -> calendarService.updateContentCalendar(calendarId, newDate, email));
+    }
+
+    @Test
+    void addGroupCalendar_정상() {
+        // given
+        Group group = new Group();
+
+        // when
+        calendarService.addGroupCalendar(email, group);
+
+        // then
+        verify(calendarRepository).save(any(Calendar.class));
+    }
+
+    @Test
+    void deleteGroupCalendar_정상() {
+        // given
+        Long groupId = 1L;
+
+        // when
+        calendarService.deleteGroupCalendar(groupId);
+
+        // then
+        verify(calendarRepository).deleteByGroupId(groupId);
+    }
+
+    @Test
+    void deleteGroupCalendarForUser_정상() {
+        // given
+        Long groupId = 1L;
+
+        // when
+        calendarService.deleteGroupCalendarForUser(email, groupId);
+
+        // then
+        verify(calendarRepository).deleteByEmailAndGroupId(email, groupId);
+    }
+
+    @Test
+    void getMonthly_정상() {
+        // given
+        YearMonth month = YearMonth.of(2025, 7);
+
+        LocalDateTime start = month.atDay(1).atStartOfDay();
+        LocalDateTime end = month.atEndOfMonth().atTime(LocalTime.MAX);
+
+        CalendarMonthlyResponse content1 = new CalendarMonthlyResponse(1L, ActivityType.CONTENT,"축제", LocalDateTime.of(2025, 7, 5, 10, 0));
+        CalendarMonthlyResponse group1 = new CalendarMonthlyResponse(2L, ActivityType.GROUP, "모임", LocalDateTime.of(2025, 7, 12, 15, 0));
+
+        // when
+        when(calendarRepository.findMonthlyContentCalendars(email, start, end))
+            .thenReturn(List.of(content1));
+        when(calendarRepository.findMonthlyGroupCalendars(email, start, end))
+            .thenReturn(List.of(group1));
+        List<CalendarMonthlyResponse> result = calendarService.getMonthly(email, month);
+
+        // then
+        assertEquals(2, result.size());
+        assertTrue(result.stream().anyMatch(r -> r.getTitle().equals("축제")));
+        assertTrue(result.stream().anyMatch(r -> r.getTitle().equals("모임")));
+    }
+
+    @Test
+    void getDaily_정상() {
+        // given
+        LocalDate date = LocalDate.of(2025, 7, 8);
+        LocalDateTime date1 = date.atTime(10, 0);
+        LocalDateTime date2 = date.atTime(9, 0);
+
+        LocalDateTime start = date.atStartOfDay();
+        LocalDateTime end = start.plusDays(1).minusNanos(1);
+
+        CalendarDailyResponse contentList = new CalendarDailyResponse(1L, ActivityType.CONTENT, "축제", date1, "축제 주소");
+        CalendarDailyResponse groupList = new CalendarDailyResponse(2L, ActivityType.GROUP, "모임", date2, "모임 주소");
+
+        // when
+        when(calendarRepository.findDailyContentCalendars(email, start, end))
+            .thenReturn(List.of(contentList));
+        when(calendarRepository.findDailyGroupCalendars(email, start, end))
+            .thenReturn(List.of(groupList));
+        List<CalendarDailyResponse> result = calendarService.getDaily(email, date);
+
+        // then
+        assertEquals(2, result.size());
+        assertEquals("모임", result.get(0).getTitle()); // 날짜 빠른 게 먼저
+        assertEquals("축제", result.get(1).getTitle());
+    }
+
+    @Test
+    void getDailyForContent_정상() {
+        // given
+        LocalDate localDate = LocalDate.of(2025, 7, 8);
+        LocalDateTime localDateTime = localDate.atTime(9, 0);
+
+        LocalDateTime start = localDate.atStartOfDay();
+        LocalDateTime end = start.plusDays(1).minusNanos(1);
+
+        CalendarDailyResponse contentList = new CalendarDailyResponse(1L, ActivityType.CONTENT, "축제", localDateTime, "축제 주소");
+
+        // when
+        when(calendarRepository.findDailyContentCalendars(email, start, end))
+            .thenReturn(List.of(contentList));
+        List<CalendarDailyResponse> result = calendarService.getDailyForContent(email, localDate);
+
+        // then
+        assertEquals(1, result.size());
+        assertTrue(result.stream().anyMatch(r -> r.getTitle().equals("축제")));
+    }
+}

--- a/src/test/java/com/grepp/funfun/app/model/calendar/service/CalendarServiceTest.java
+++ b/src/test/java/com/grepp/funfun/app/model/calendar/service/CalendarServiceTest.java
@@ -200,8 +200,8 @@ class CalendarServiceTest {
         LocalDateTime start = month.atDay(1).atStartOfDay();
         LocalDateTime end = month.atEndOfMonth().atTime(LocalTime.MAX);
 
-        CalendarMonthlyResponse content1 = new CalendarMonthlyResponse(1L, ActivityType.CONTENT,"축제", LocalDateTime.of(2025, 7, 5, 10, 0));
-        CalendarMonthlyResponse group1 = new CalendarMonthlyResponse(2L, ActivityType.GROUP, "모임", LocalDateTime.of(2025, 7, 12, 15, 0));
+        CalendarMonthlyResponse content1 = new CalendarMonthlyResponse(1L, ActivityType.CONTENT,1L, "축제", LocalDateTime.of(2025, 7, 5, 10, 0));
+        CalendarMonthlyResponse group1 = new CalendarMonthlyResponse(2L, ActivityType.GROUP, 1L, "모임", LocalDateTime.of(2025, 7, 12, 15, 0));
 
         // when
         when(calendarRepository.findMonthlyContentCalendars(email, start, end))
@@ -226,8 +226,8 @@ class CalendarServiceTest {
         LocalDateTime start = date.atStartOfDay();
         LocalDateTime end = start.plusDays(1).minusNanos(1);
 
-        CalendarDailyResponse contentList = new CalendarDailyResponse(1L, ActivityType.CONTENT, "축제", date1, "축제 주소");
-        CalendarDailyResponse groupList = new CalendarDailyResponse(2L, ActivityType.GROUP, "모임", date2, "모임 주소");
+        CalendarDailyResponse contentList = new CalendarDailyResponse(1L, ActivityType.CONTENT, 1L, "축제", date1, "축제 주소");
+        CalendarDailyResponse groupList = new CalendarDailyResponse(2L, ActivityType.GROUP, 1L, "모임", date2, "모임 주소");
 
         // when
         when(calendarRepository.findDailyContentCalendars(email, start, end))
@@ -251,7 +251,7 @@ class CalendarServiceTest {
         LocalDateTime start = localDate.atStartOfDay();
         LocalDateTime end = start.plusDays(1).minusNanos(1);
 
-        CalendarDailyResponse contentList = new CalendarDailyResponse(1L, ActivityType.CONTENT, "축제", localDateTime, "축제 주소");
+        CalendarDailyResponse contentList = new CalendarDailyResponse(1L, ActivityType.CONTENT, 1L, "축제", localDateTime, "축제 주소");
 
         // when
         when(calendarRepository.findDailyContentCalendars(email, start, end))


### PR DESCRIPTION
## 📌 과제 설명
캘린더 기능 구현했습니다.
## 👩‍💻 요구 사항과 구현 내용
* 일정 등록
* 일정 삭제
  * 사용자는 컨텐츠 타입의 일정만 직접 삭제 가능 
* 일정 수정
  * 사용자는 컨텐츠 타입의 일정만 직접 수정 가능
* 월별 일정 조회 
  * 모임, 컨텐츠 모두 조회 
* 일별 일정 조회
  * 모임, 컨텐츠 모두 조회 
* 컨텐츠 일별 일정 조회
* 모임 / 캘린더 연동
  * 모임 생성 시 리더 일정 자동 등록
  * 모임 삭제/취소 시 참여자 일정 자동 삭제
  * 모임 참여 시 일정 자동 등록
  * 모임 강퇴/나가기 시 일정 자동 삭제
