### PR TITLE
feat: 프로필 기능 구현

### DIFF
--- a/src/main/java/com/grepp/funfun/app/domain/group/repository/GroupRepository.java
+++ b/src/main/java/com/grepp/funfun/app/domain/group/repository/GroupRepository.java
@@ -1,6 +1,7 @@
 package com.grepp.funfun.app.domain.group.repository;
 
 import com.grepp.funfun.app.domain.group.entity.Group;
+import com.grepp.funfun.app.domain.group.vo.GroupStatus;
 import com.grepp.funfun.app.domain.user.entity.User;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +11,5 @@ public interface GroupRepository extends JpaRepository<Group, Long>, GroupReposi
 
     Group findFirstByLeader(User user);
 
+    long countByLeaderEmailAndStatus(String email, GroupStatus groupStatus);
 }

--- a/src/main/java/com/grepp/funfun/app/domain/group/service/GroupService.java
+++ b/src/main/java/com/grepp/funfun/app/domain/group/service/GroupService.java
@@ -286,6 +286,10 @@ public class GroupService {
         return response;
     }
 
+    public long countLeadGroupByEmail(String email) {
+        return groupRepository.countByLeaderEmailAndStatus(email, GroupStatus.COMPLETED);
+    }
+
     private GroupDTO mapToDTO(final Group group, final GroupDTO groupDTO) {
         groupDTO.setId(group.getId());
         groupDTO.setTitle(group.getTitle());

--- a/src/main/java/com/grepp/funfun/app/domain/participant/repository/ParticipantRepository.java
+++ b/src/main/java/com/grepp/funfun/app/domain/participant/repository/ParticipantRepository.java
@@ -2,6 +2,8 @@ package com.grepp.funfun.app.domain.participant.repository;
 
 import com.grepp.funfun.app.domain.group.entity.Group;
 import com.grepp.funfun.app.domain.participant.entity.Participant;
+import com.grepp.funfun.app.domain.participant.vo.ParticipantRole;
+import com.grepp.funfun.app.domain.participant.vo.ParticipantStatus;
 import com.grepp.funfun.app.domain.user.entity.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,4 +20,6 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long>,
     Optional<Participant> findByGroupIdAndUserEmail(Long groupId,String userEmail);
 
     String user(User user);
+
+    long countByUserEmailAndRoleAndStatus(String email, ParticipantRole participantRole, ParticipantStatus participantStatus);
 }

--- a/src/main/java/com/grepp/funfun/app/domain/participant/service/ParticipantService.java
+++ b/src/main/java/com/grepp/funfun/app/domain/participant/service/ParticipantService.java
@@ -241,6 +241,14 @@ public class ParticipantService {
             .map(ParticipantResponse::from)
             .collect(Collectors.toList());
     }
+
+    public long countJoinGroupByEmail(String email) {
+        return participantRepository.countByUserEmailAndRoleAndStatus(
+            email,
+            ParticipantRole.MEMBER,
+            ParticipantStatus.GROUP_COMPLETE
+        );
+    }
     // ------------------------------여기 까지 ------------------------------------
 
     public List<ParticipantDTO> findAll() {

--- a/src/main/java/com/grepp/funfun/app/domain/social/repository/FollowRepository.java
+++ b/src/main/java/com/grepp/funfun/app/domain/social/repository/FollowRepository.java
@@ -15,7 +15,7 @@ public interface FollowRepository extends JpaRepository<Follow, Long>, FollowRep
 
     void deleteByFollowerEmailAndFolloweeEmail(String followerEmail, String followeeEmail);
 
-    Long countByFolloweeEmail(String followeeEmail);
+    long countByFolloweeEmail(String followeeEmail);
 
-    Long countByFollowerEmail(String followerEmail);
+    long countByFollowerEmail(String followerEmail);
 }

--- a/src/main/java/com/grepp/funfun/app/domain/social/service/FollowService.java
+++ b/src/main/java/com/grepp/funfun/app/domain/social/service/FollowService.java
@@ -64,11 +64,11 @@ public class FollowService {
         return followRepository.findFollowingsByFollowerEmail(email);
     }
 
-    public Long countFollowers(String email) {
+    public long countFollowers(String email) {
         return followRepository.countByFolloweeEmail(email);
     }
 
-    public Long countFollowings(String email) {
+    public long countFollowings(String email) {
         return followRepository.countByFollowerEmail(email);
     }
 

--- a/src/main/java/com/grepp/funfun/app/domain/user/controller/UserInfoApiController.java
+++ b/src/main/java/com/grepp/funfun/app/domain/user/controller/UserInfoApiController.java
@@ -1,6 +1,7 @@
 package com.grepp.funfun.app.domain.user.controller;
 
 import com.grepp.funfun.app.domain.user.dto.payload.ProfileRequest;
+import com.grepp.funfun.app.domain.user.dto.payload.UserDetailResponse;
 import com.grepp.funfun.app.domain.user.service.UserInfoService;
 import com.grepp.funfun.app.infra.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,7 +10,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -46,5 +49,27 @@ public class UserInfoApiController {
         String email = authentication.getName();
         userInfoService.update(email, request);
         return ResponseEntity.ok(ApiResponse.success("프로필이 수정되었습니다."));
+    }
+
+    @GetMapping("/{email}")
+    @Operation(
+        summary = "유저 상세 조회",
+        description = """
+            유저의 상세 정보를 이메일로 조회합니다.<br><br>
+            응답 필드 설명:<br>
+            - email: 이메일<br>
+            - nickname: 닉네임<br>
+            - introduction: 한 줄 소개<br>
+            - imageUrl: 프로필 이미지 URL<br>
+            - hashtags: 해시태그 리스트<br>
+            - followerCount: 팔로워 수<br>
+            - followingCount: 팔로잉 수<br>
+            - groupLeadCount: 본인이 주최한 완료된 모임 수<br>
+            - groupJoinCount: 본인이 참여한 완료된 모임 수 (리더 제외)
+            """
+    )
+    public ResponseEntity<ApiResponse<UserDetailResponse>> getUserDetail(
+        @PathVariable String email) {
+        return ResponseEntity.ok(ApiResponse.success(userInfoService.getUserDetail(email)));
     }
 }

--- a/src/main/java/com/grepp/funfun/app/domain/user/dto/UserDTO.java
+++ b/src/main/java/com/grepp/funfun/app/domain/user/dto/UserDTO.java
@@ -26,6 +26,8 @@ public class UserDTO {
     @Size(max = 255)
     private String nickname;
 
+    private String birthDate;
+
     private Integer age;
 
     private Gender gender;

--- a/src/main/java/com/grepp/funfun/app/domain/user/dto/UserInfoDTO.java
+++ b/src/main/java/com/grepp/funfun/app/domain/user/dto/UserInfoDTO.java
@@ -1,6 +1,7 @@
 package com.grepp.funfun.app.domain.user.dto;
 
 import jakarta.validation.constraints.Size;
+import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -18,4 +19,5 @@ public class UserInfoDTO {
     @Size(max = 255)
     private String introduction;
 
+    private List<String> hashtags;
 }

--- a/src/main/java/com/grepp/funfun/app/domain/user/dto/payload/ProfileRequest.java
+++ b/src/main/java/com/grepp/funfun/app/domain/user/dto/payload/ProfileRequest.java
@@ -1,0 +1,19 @@
+package com.grepp.funfun.app.domain.user.dto.payload;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.Data;
+import org.springframework.web.multipart.MultipartFile;
+
+@Data
+public class ProfileRequest {
+
+    private MultipartFile image;
+
+    @NotNull(message = "이미지 변경 여부는 필수입니다.")
+    private boolean imageChanged;
+
+    private String introduction;
+
+    private List<String> hashTags;
+}

--- a/src/main/java/com/grepp/funfun/app/domain/user/dto/payload/UserDetailResponse.java
+++ b/src/main/java/com/grepp/funfun/app/domain/user/dto/payload/UserDetailResponse.java
@@ -1,0 +1,19 @@
+package com.grepp.funfun.app.domain.user.dto.payload;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class UserDetailResponse {
+    private String email;
+    private String nickname;
+    private String introduction;
+    private String imageUrl;
+    private List<String> hashtags;
+    private long followerCount;
+    private long followingCount;
+    private long groupLeadCount;
+    private long groupJoinCount;
+}

--- a/src/main/java/com/grepp/funfun/app/domain/user/entity/UserHashtag.java
+++ b/src/main/java/com/grepp/funfun/app/domain/user/entity/UserHashtag.java
@@ -1,0 +1,30 @@
+package com.grepp.funfun.app.domain.user.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserHashtag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String tag;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "info_id")
+    private UserInfo info;
+}

--- a/src/main/java/com/grepp/funfun/app/domain/user/entity/UserInfo.java
+++ b/src/main/java/com/grepp/funfun/app/domain/user/entity/UserInfo.java
@@ -1,15 +1,25 @@
 package com.grepp.funfun.app.domain.user.entity;
 
 import com.grepp.funfun.app.infra.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 
 @Entity
 @Getter
 @Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class UserInfo extends BaseEntity {
 
     @Id
@@ -19,4 +29,6 @@ public class UserInfo extends BaseEntity {
 
     private String introduction;
 
+    @OneToMany(mappedBy = "info",cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<UserHashtag> hashtags = new ArrayList<>();
 }

--- a/src/main/java/com/grepp/funfun/app/domain/user/repository/UserHashtagRepository.java
+++ b/src/main/java/com/grepp/funfun/app/domain/user/repository/UserHashtagRepository.java
@@ -1,0 +1,10 @@
+package com.grepp.funfun.app.domain.user.repository;
+
+import com.grepp.funfun.app.domain.user.entity.UserHashtag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface UserHashtagRepository extends JpaRepository<UserHashtag, Long> {
+
+    void deleteByInfoEmail(String email);
+}

--- a/src/main/java/com/grepp/funfun/app/domain/user/service/UserInfoService.java
+++ b/src/main/java/com/grepp/funfun/app/domain/user/service/UserInfoService.java
@@ -1,30 +1,65 @@
 package com.grepp.funfun.app.domain.user.service;
 
+import com.grepp.funfun.app.domain.s3.service.S3FileService;
 import com.grepp.funfun.app.domain.user.dto.UserInfoDTO;
+import com.grepp.funfun.app.domain.user.dto.payload.ProfileRequest;
 import com.grepp.funfun.app.domain.user.entity.User;
+import com.grepp.funfun.app.domain.user.entity.UserHashtag;
 import com.grepp.funfun.app.domain.user.entity.UserInfo;
+import com.grepp.funfun.app.domain.user.repository.UserHashtagRepository;
 import com.grepp.funfun.app.domain.user.repository.UserInfoRepository;
 import com.grepp.funfun.app.domain.user.repository.UserRepository;
 import com.grepp.funfun.app.infra.error.exceptions.CommonException;
 import com.grepp.funfun.app.infra.response.ResponseCode;
 import com.grepp.funfun.app.delete.util.ReferencedWarning;
 import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 
 @Service
+@RequiredArgsConstructor
 public class UserInfoService {
 
     private final UserInfoRepository userInfoRepository;
     private final UserRepository userRepository;
+    private final UserHashtagRepository userHashtagRepository;
+    private final S3FileService s3FileService;
 
-    public UserInfoService(final UserInfoRepository userInfoRepository,
-            final UserRepository userRepository) {
-        this.userInfoRepository = userInfoRepository;
-        this.userRepository = userRepository;
+    @Transactional
+    public void update(String email, ProfileRequest request) {
+        User user = userRepository.findById(email)
+            .orElseThrow(() -> new CommonException(ResponseCode.NOT_FOUND));
+
+        UserInfo userInfo = user.getInfo();
+
+        // 1. 소개글 변경
+        userInfo.setIntroduction(request.getIntroduction());
+
+        // 2. 해시태그 변경 (전체 삭제 후 재등록)
+        userHashtagRepository.deleteByInfoEmail(email);
+        List<UserHashtag> newTags = Optional.ofNullable(request.getHashTags())
+            .orElse(List.of()).stream()
+            .map(tag -> UserHashtag.builder().info(userInfo).tag(tag).build())
+            .toList();
+        userHashtagRepository.saveAll(newTags);
+
+        // 3. 이미지 처리
+        if (request.isImageChanged()) {
+            if (request.getImage() != null && !request.getImage().isEmpty()) {
+                // 새 이미지 업로드
+                String newImageUrl = s3FileService.upload(request.getImage(), "user");
+                userInfo.setImageUrl(newImageUrl);
+            } else {
+                userInfo.setImageUrl(null);
+            }
+        }
     }
 
+    @Transactional(readOnly = true)
     public List<UserInfoDTO> findAll() {
         final List<UserInfo> userInfoes = userInfoRepository.findAll(Sort.by("email"));
         return userInfoes.stream()
@@ -60,6 +95,11 @@ public class UserInfoService {
         userInfoDTO.setEmail(userInfo.getEmail());
         userInfoDTO.setImageUrl(userInfo.getImageUrl());
         userInfoDTO.setIntroduction(userInfo.getIntroduction());
+        userInfoDTO.setHashtags(
+            userInfo.getHashtags().stream()
+                .map(UserHashtag::getTag)
+                .toList()
+        );
         return userInfoDTO;
     }
 

--- a/src/main/java/com/grepp/funfun/app/domain/user/service/UserService.java
+++ b/src/main/java/com/grepp/funfun/app/domain/user/service/UserService.java
@@ -293,6 +293,7 @@ public class UserService {
         userDTO.setEmail(user.getEmail());
         userDTO.setPassword(user.getPassword());
         userDTO.setNickname(user.getNickname());
+        userDTO.setBirthDate(user.getBirthDate());
         userDTO.setGender(user.getGender());
         userDTO.setAddress(user.getAddress());
         userDTO.setRole(user.getRole());

--- a/src/main/resources/templates/user/list.html
+++ b/src/main/resources/templates/user/list.html
@@ -20,11 +20,16 @@
                             <th scope="col">[[#{user.email.label}]]</th>
                             <th scope="col">[[#{user.password.label}]]</th>
                             <th scope="col">[[#{user.nickname.label}]]</th>
-                            <th scope="col">[[#{user.age.label}]]</th>
+                            <th scope="col">BirthDate</th>
                             <th scope="col">[[#{user.gender.label}]]</th>
-                            <th scope="col">[[#{user.tel.label}]]</th>
                             <th scope="col">[[#{user.address.label}]]</th>
                             <th scope="col">[[#{user.role.label}]]</th>
+                            <th scope="col">[[#{user.status.label}]]</th>
+                            <th scope="col">[[#{user.dueDate.label}]]</th>
+                            <th scope="col">[[#{user.suspendDuration.label}]]</th>
+                            <th scope="col">[[#{user.dueReason.label}]]</th>
+                            <th scope="col">[[#{user.isVerified.label}]]</th>
+                            <th scope="col">[[#{user.isMarketingAgreed.label}]]</th>
                             <th><!-- --></th>
                         </tr>
                     </thead>
@@ -33,11 +38,16 @@
                             <td>[[${user.email}]]</td>
                             <td>[[${user.password}]]</td>
                             <td>[[${user.nickname}]]</td>
-                            <td>[[${user.age}]]</td>
+                            <td>[[${user.birthDate}]]</td>
                             <td>[[${user.gender}]]</td>
-                            <td>[[${user.tel}]]</td>
                             <td>[[${user.address}]]</td>
                             <td>[[${user.role}]]</td>
+                            <td>[[${user.status}]]</td>
+                            <td>[[${user.dueDate}]]</td>
+                            <td>[[${user.suspendDuration}]]</td>
+                            <td>[[${user.dueReason}]]</td>
+                            <td>[[${user.isVerified}]]</td>
+                            <td>[[${user.isMarketingAgreed}]]</td>
                             <td>
                                 <div class="float-end text-nowrap">
                                     <a th:href="@{/users/edit/{email}(email=${user.email})}" class="btn btn-sm btn-secondary">[[#{user.list.edit}]]</a>

--- a/src/main/resources/templates/userInfo/list.html
+++ b/src/main/resources/templates/userInfo/list.html
@@ -20,14 +20,18 @@
                             <th scope="col">[[#{userInfo.email.label}]]</th>
                             <th scope="col">[[#{userInfo.imageUrl.label}]]</th>
                             <th scope="col">[[#{userInfo.introduction.label}]]</th>
+                            <th scope="col">Hashtags</th>
                             <th><!-- --></th>
                         </tr>
                     </thead>
                     <tbody>
                         <tr th:each="userInfo : ${userInfoes}">
                             <td>[[${userInfo.email}]]</td>
-                            <td>[[${userInfo.imageUrl}]]</td>
+                            <td>
+                                <img th:src="${userInfo.imageUrl}" alt="프로필 이미지" style="max-width: 100px; max-height: 100px;">
+                            </td>
                             <td>[[${userInfo.introduction}]]</td>
+                            <td>[[${userInfo.hashtags}]]</td>
                             <td>
                                 <div class="float-end text-nowrap">
                                     <a th:href="@{/userInfos/edit/{email}(email=${userInfo.email})}" class="btn btn-sm btn-secondary">[[#{userInfo.list.edit}]]</a>


### PR DESCRIPTION
## 📌 과제 설명
프로필 기능 구현했습니다.
## 👩‍💻 요구 사항과 구현 내용
* 사진 업로드 기능
  * S3FileService 수정으로 이미지를 S3에 업로드할 수 있습니다.
  * 반환되는 Url로 이미지에 접근 가능합니다. 
* 프로필 수정 기능
  *  해시태그 필드를 추가했습니다.
* Bootify Users 페이지에 모든 항목이 나오게 수정했습니다. 
* 유저 상세 조회 기능
  * 기본 UserInfo 필드 조회 (이메일, 한 줄 소개, 이미지, 해시태그)
  * 닉네임 조회
  * 팔로워, 팔로잉 수 조회
  * 그룹 주최 수, 그룹 참여 수 (완료된 모임 기준)
  * 이 부분은 프론트 피그마 페이지가 없어서 임의로 응답 형태를 설정했습니다.
## ✅ PR 포인트 & 궁금한 점
* application.properties에 추가 사항 있습니다.
`cloud.aws.s3.url=https://team08-funfun.s3.ap-northeast-2.amazonaws.com/`
* UserInfo에 Hashtag 필드 추가로 데이터 베이스 update 필요합니다.