### PR TITLE
feat: 모임 조회 기능 추가

### DIFF
--- a/src/main/java/com/grepp/funfun/app/delete/controller/web/group/GroupController.java
+++ b/src/main/java/com/grepp/funfun/app/delete/controller/web/group/GroupController.java
@@ -12,6 +12,7 @@ import com.grepp.funfun.app.delete.util.WebUtils;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -41,8 +42,10 @@ public class GroupController {
     }
 
     @GetMapping
-    public String list(final Model model) {
-        model.addAttribute("groups", groupService.getRecentGroups());
+    public String list(final Model model, Authentication authentication) {
+        String userEmail = authentication.getName();
+
+        model.addAttribute("groups", groupService.getGroups(null, null, null, userEmail));
         return "group/list";
     }
 
@@ -61,12 +64,6 @@ public class GroupController {
         groupService.create(leaderEmail,request);
         redirectAttributes.addFlashAttribute(WebUtils.MSG_SUCCESS, WebUtils.getMessage("group.create.success"));
         return "redirect:/groups";
-    }
-
-    @GetMapping("/edit/{id}")
-    public String edit(@PathVariable(name = "id") final Long id, final Model model) {
-        model.addAttribute("group", groupService.get(id));
-        return "group/edit";
     }
 
     @PostMapping("/edit/{id}")

--- a/src/main/java/com/grepp/funfun/app/domain/group/controller/GroupApiController.java
+++ b/src/main/java/com/grepp/funfun/app/domain/group/controller/GroupApiController.java
@@ -43,6 +43,16 @@ public class GroupApiController {
         return ResponseEntity.ok(ApiResponse.success(groupService.get(groupId,userEmail)));
     }
 
+    // 내가 리더인 모임 조회
+    @GetMapping("/getLeaderMy")
+    @Operation(summary = "내가 리더 역할인 모임 조회", description = "내가 리더 역할인 모임을 조회합니다.")
+    public ResponseEntity<ApiResponse<List<GroupResponse>>> getLeaderMyGroups(
+        Authentication authentication
+    ){
+        String userEmail = authentication.getName();
+        return ResponseEntity.ok(ApiResponse.success(groupService.findMyLeaderGroups(userEmail)));
+    }
+
     // 내가 속한 모임 조회
     @GetMapping("/getMy")
     @Operation(summary = "내가 속한 모임 조회", description = "내가 속한 모임을 조회합니다.")

--- a/src/main/java/com/grepp/funfun/app/domain/group/controller/GroupApiController.java
+++ b/src/main/java/com/grepp/funfun/app/domain/group/controller/GroupApiController.java
@@ -16,11 +16,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 
@@ -35,25 +37,10 @@ public class GroupApiController {
     // 모임 상세 조회
     @GetMapping("/{groupId}")
     @Operation(summary = "모임 상세 조회", description = "모임을 상세 조회합니다.")
-    public ResponseEntity<ApiResponse<GroupResponse>> getGroup(@PathVariable Long groupId) {
-        return ResponseEntity.ok(ApiResponse.success(groupService.get(groupId)));
-    }
-
-    // 모든 모임 조회(최신순)
-    @GetMapping("/getRecent")
-    @Operation(summary = "모든 모임 조회(최신순)", description = "모든 모임을 조회합니다.(최신순)")
-    public ResponseEntity<ApiResponse<List<GroupResponse>>> getAllRecentGroups() {
-        return ResponseEntity.ok(ApiResponse.success(groupService.getRecentGroups()));
-    }
-
-    // 모든 모임 조회(가까운순)
-    @GetMapping("/getNearby")
-    @Operation(summary = "모든 모임 조회(거리순)", description = "모든 모임을 조회합니다.(거리순)")
-    public ResponseEntity<ApiResponse<List<GroupResponse>>> getAllNearbyGroups(
-        Authentication authentication
-    ) {
-        String userEmail = authentication.getName();
-        return ResponseEntity.ok(ApiResponse.success(groupService.findNearGroups(userEmail)));
+    public ResponseEntity<ApiResponse<GroupResponse>> getGroup(@PathVariable Long groupId,
+        Authentication authentication) {
+        String userEmail = authentication != null ? authentication.getName() : null;
+        return ResponseEntity.ok(ApiResponse.success(groupService.get(groupId,userEmail)));
     }
 
     // 내가 속한 모임 조회
@@ -66,10 +53,41 @@ public class GroupApiController {
         return ResponseEntity.ok(ApiResponse.success(groupService.findMyGroups(userEmail)));
     }
 
+
+    @GetMapping("/search")
+    @Operation(summary = "모임 검색 및 조회", description = """
+            아래와 형식으로 입력해주세요.
+            
+            • category(null 허용)
+            - ART, TRAVEL, FOOD,GAME,CULTURE,SPORT,STUDY,MOVIE
+            
+            • keyword(null 허용)
+            - 검색을 원하는 키워드
+           
+            • sortBy
+            - recent(최신순) , viewCount(조회수) , distance(거리순)
+            - 처음 접속했을 때 모든 기준 초기값 : 거리순
+            
+            ex)
+            ART / 모임 / recent
+            아무것도 넣지 않고, 검색하면 거리순
+            """
+    )
+    // 통합 모임 조회 - 검색/필터링/정렬(최신순,조회순,거리순) -> default 거리순
+    public ResponseEntity<ApiResponse<List<GroupResponse>>> searchGroups(
+        @RequestParam(required = false) String category,
+        @RequestParam(required = false) String keyword,
+        @RequestParam(defaultValue = "distance") String sortBy,
+        Authentication authentication
+    ) {
+        String userEmail = authentication != null ? authentication.getName() : null;
+        return ResponseEntity.ok(ApiResponse.success(groupService.getGroups(category, keyword, sortBy, userEmail)));
+    }
+
     // 모임 생성
-    @PostMapping("/create")
+    @PostMapping(value = "/create", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "모임 생성", description = "모임을 생성합니다.")
-    public ResponseEntity<ApiResponse<String>> createGroup(@RequestBody @Valid GroupRequest request,
+    public ResponseEntity<ApiResponse<String>> createGroup(@ModelAttribute @Valid GroupRequest request,
         Authentication authentication) {
         try {
             String leaderEmail = authentication.getName();
@@ -83,10 +101,10 @@ public class GroupApiController {
     }
 
     // 모임 수정
-    @PutMapping("{groupId}")
+    @PutMapping(value = "/{groupId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "모임 수정", description = "모임을 수정합니다.")
     public ResponseEntity<ApiResponse<String>> updateGroup(@PathVariable Long groupId,
-        @RequestBody GroupRequest updateRequest, Authentication authentication) {
+        @ModelAttribute @Valid GroupRequest updateRequest, Authentication authentication) {
         try {
             String leaderEmail = authentication.getName();
             groupService.update(groupId, leaderEmail, updateRequest);

--- a/src/main/java/com/grepp/funfun/app/domain/group/dto/payload/GroupRequest.java
+++ b/src/main/java/com/grepp/funfun/app/domain/group/dto/payload/GroupRequest.java
@@ -13,6 +13,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.multipart.MultipartFile;
 
 @Data
 @Slf4j
@@ -33,6 +35,7 @@ public class GroupRequest {
     private String placeName;
 
     @NotNull(message="모임 시간은 필수입니다.")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     private LocalDateTime groupDate;
 
     //모임 주소
@@ -54,15 +57,40 @@ public class GroupRequest {
     @NotNull(message = "경도는 필수입니다.")
     private Double longitude;
 
+    private MultipartFile image;
+
     @NotEmpty(message="해시태그는 1개 이상 선택해야합니다.")
     private List<String> hashTags;
 
     @Min(value = 1, message = "최소 1시간 이상이어야 합니다.")  // message 추가
     private Integer during;
 
-    public Group toEntity(User leader){
+    public Group mapToCreate(User leader, String imageUrl) {
         return Group.builder()
             .leader(leader)
+            .title(this.title)
+            .explain(this.explain)
+            .simpleExplain(this.simpleExplain)
+            .placeName(this.placeName)
+            .groupDate(this.groupDate)
+            .viewCount(0)
+            .address(this.address)
+            .category(this.category)
+            .maxPeople(this.maxPeople)
+            .nowPeople(1)
+            .imageUrl(imageUrl)
+            .status(GroupStatus.RECRUITING)
+            .latitude(this.latitude)
+            .longitude(this.longitude)
+            .during(this.during)
+            .build();
+    }
+
+    // 수정용 메서드
+    public Group mapToUpdate(Group existingGroup, String newImageUrl) {
+        return Group.builder()
+            .id(existingGroup.getId())
+            .leader(existingGroup.getLeader())
             .title(this.title)
             .explain(this.explain)
             .simpleExplain(this.simpleExplain)
@@ -71,12 +99,14 @@ public class GroupRequest {
             .address(this.address)
             .category(this.category)
             .maxPeople(this.maxPeople)
-            .nowPeople(1)
-            .status(GroupStatus.RECRUITING)
             .latitude(this.latitude)
             .longitude(this.longitude)
             .during(this.during)
+            .imageUrl(newImageUrl != null ? newImageUrl : existingGroup.getImageUrl())
+            .viewCount(existingGroup.getViewCount())
+            .nowPeople(existingGroup.getNowPeople())
+            .status(existingGroup.getStatus())
             .build();
     }
-
 }
+

--- a/src/main/java/com/grepp/funfun/app/domain/group/dto/payload/GroupResponse.java
+++ b/src/main/java/com/grepp/funfun/app/domain/group/dto/payload/GroupResponse.java
@@ -53,7 +53,9 @@ public class GroupResponse {
 
     @NotNull
     @Size(max = 255)
-    private String leader;
+    private String leaderNickname;
+
+    private String leaderEmail;
 
     private List<String> hashTags;
 

--- a/src/main/java/com/grepp/funfun/app/domain/group/dto/payload/GroupResponse.java
+++ b/src/main/java/com/grepp/funfun/app/domain/group/dto/payload/GroupResponse.java
@@ -31,7 +31,11 @@ public class GroupResponse {
     @Size(max = 255)
     private String address;
 
+    private Integer viewCount;
+
     private LocalDateTime groupDate;
+
+    private LocalDateTime createdAt;
 
     private Integer maxPeople;
 

--- a/src/main/java/com/grepp/funfun/app/domain/group/entity/Group.java
+++ b/src/main/java/com/grepp/funfun/app/domain/group/entity/Group.java
@@ -8,6 +8,7 @@ import com.grepp.funfun.app.domain.participant.entity.Participant;
 import com.grepp.funfun.app.domain.user.entity.User;
 import com.grepp.funfun.app.infra.entity.BaseEntity;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -45,6 +46,9 @@ public class Group extends BaseEntity {
 
     // 모임 소개
     private String explain;
+
+    // 모임 조회수
+    private Integer viewCount = 0;
 
     // 모임 한 줄 소개
     private String simpleExplain;
@@ -84,5 +88,14 @@ public class Group extends BaseEntity {
 
     @OneToMany(mappedBy = "group",cascade = CascadeType.ALL)
     private List<GroupHashtag> hashtags;
+
+    public void updateViewCount(Integer viewCount) {
+        this.viewCount = viewCount;
+    }
+
+    public void changeStatusAndActivated(GroupStatus status) {
+        this.unActivated();
+        this.status = status;
+    }
 
 }

--- a/src/main/java/com/grepp/funfun/app/domain/group/repository/GroupHashtagRepository.java
+++ b/src/main/java/com/grepp/funfun/app/domain/group/repository/GroupHashtagRepository.java
@@ -9,4 +9,5 @@ public interface GroupHashtagRepository extends JpaRepository<GroupHashtag, Long
 
     GroupHashtag findFirstByGroup(Group group);
 
+    void deleteByGroup(Group group);
 }

--- a/src/main/java/com/grepp/funfun/app/domain/group/repository/GroupRepository.java
+++ b/src/main/java/com/grepp/funfun/app/domain/group/repository/GroupRepository.java
@@ -12,4 +12,6 @@ public interface GroupRepository extends JpaRepository<Group, Long>, GroupReposi
     Group findFirstByLeader(User user);
 
     long countByLeaderEmailAndStatus(String email, GroupStatus groupStatus);
+
+    List<Group> findByLeaderEmail(String email);
 }

--- a/src/main/java/com/grepp/funfun/app/domain/group/repository/GroupRepositoryCustom.java
+++ b/src/main/java/com/grepp/funfun/app/domain/group/repository/GroupRepositoryCustom.java
@@ -14,14 +14,8 @@ public interface GroupRepositoryCustom {
     // 내 모임 조회
     List<Group> findMyGroups(String userEmail);
 
-    // 최신순
-    List<Group> findActiveRecentGroups();
-
-    // 키워드 조회(검색)
-    List<Group> findGroupsByKeyword(String keyword);
-
-    // 가까운 순 조회
-    List<Group> findNearbyGroups(Double userLat, Double userLng);
+    // 모임 조회
+    List<Group> findGroups(String category, String keyword, String sortBy, String userEmail);
 
     // 모임 상세 조회
     Optional<Group> findByIdWithFullInfo(Long groupId);

--- a/src/main/java/com/grepp/funfun/app/domain/group/repository/GroupRepositoryCustom.java
+++ b/src/main/java/com/grepp/funfun/app/domain/group/repository/GroupRepositoryCustom.java
@@ -11,7 +11,7 @@ public interface GroupRepositoryCustom {
     // 모집중인 모임 조회
     Optional<Group> findActiveRecruitingGroup(Long groupId);
 
-    // 내 모임 조회
+    // 내 모임 조회(채팅용)
     List<Group> findMyGroups(String userEmail);
 
     // 모임 조회

--- a/src/main/java/com/grepp/funfun/app/domain/group/scheduler/ViewCountScheduler.java
+++ b/src/main/java/com/grepp/funfun/app/domain/group/scheduler/ViewCountScheduler.java
@@ -1,0 +1,48 @@
+package com.grepp.funfun.app.domain.group.scheduler;
+
+import com.grepp.funfun.app.domain.group.repository.GroupRepository;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class ViewCountScheduler {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final GroupRepository groupRepository;
+
+    // 1분
+    @Scheduled(fixedDelay = 60000)
+    public void viewCountToDatabase() {
+        try {
+            Set<String> keys = redisTemplate.keys("group:*:viewCount");
+
+            for (String key : keys) {
+                Long groupId = extractGroupId(key);
+                String viewCountStr = redisTemplate.opsForValue().get(key);
+
+                if (viewCountStr != null) {
+                    Integer viewCount = Integer.parseInt(viewCountStr);
+
+                    groupRepository.findById(groupId).ifPresent(group -> {
+                        group.updateViewCount(viewCount);
+                        groupRepository.save(group);
+                    });
+
+                }
+            }
+        } catch (Exception e) {
+            log.error("Failed to sync view count to database", e);
+        }
+    }
+
+    private Long extractGroupId(String key) {
+        String[] parts = key.split(":");
+        return Long.parseLong(parts[1]);
+    }
+}

--- a/src/main/java/com/grepp/funfun/app/domain/group/service/GroupService.java
+++ b/src/main/java/com/grepp/funfun/app/domain/group/service/GroupService.java
@@ -1,37 +1,40 @@
 package com.grepp.funfun.app.domain.group.service;
 
-import com.grepp.funfun.app.domain.chat.entity.GroupChatRoom;
-import com.grepp.funfun.app.domain.chat.vo.ChatRoomType;
-import com.grepp.funfun.app.domain.group.dto.payload.GroupMyResponse;
-import com.grepp.funfun.app.domain.group.dto.payload.GroupRequest;
-import com.grepp.funfun.app.domain.group.dto.payload.GroupResponse;
+import com.grepp.funfun.app.delete.util.ReferencedWarning;
 import com.grepp.funfun.app.domain.bookmark.entity.GroupBookmark;
 import com.grepp.funfun.app.domain.bookmark.repository.GroupBookmarkRepository;
 import com.grepp.funfun.app.domain.calendar.entity.Calendar;
 import com.grepp.funfun.app.domain.calendar.repository.CalendarRepository;
 import com.grepp.funfun.app.domain.calendar.service.CalendarService;
+import com.grepp.funfun.app.domain.chat.entity.GroupChatRoom;
 import com.grepp.funfun.app.domain.chat.repository.GroupChatRoomRepository;
-import com.grepp.funfun.app.domain.group.vo.GroupStatus;
-import com.grepp.funfun.app.domain.group.dto.GroupDTO;
+import com.grepp.funfun.app.domain.chat.vo.ChatRoomType;
+import com.grepp.funfun.app.domain.group.dto.payload.GroupMyResponse;
+import com.grepp.funfun.app.domain.group.dto.payload.GroupRequest;
+import com.grepp.funfun.app.domain.group.dto.payload.GroupResponse;
 import com.grepp.funfun.app.domain.group.entity.Group;
 import com.grepp.funfun.app.domain.group.entity.GroupHashtag;
 import com.grepp.funfun.app.domain.group.repository.GroupHashtagRepository;
 import com.grepp.funfun.app.domain.group.repository.GroupRepository;
-import com.grepp.funfun.app.domain.participant.vo.ParticipantRole;
-import com.grepp.funfun.app.domain.participant.vo.ParticipantStatus;
+import com.grepp.funfun.app.domain.group.vo.GroupStatus;
 import com.grepp.funfun.app.domain.participant.entity.Participant;
 import com.grepp.funfun.app.domain.participant.repository.ParticipantRepository;
+import com.grepp.funfun.app.domain.participant.vo.ParticipantRole;
+import com.grepp.funfun.app.domain.participant.vo.ParticipantStatus;
+import com.grepp.funfun.app.domain.s3.service.S3FileService;
 import com.grepp.funfun.app.domain.user.entity.User;
 import com.grepp.funfun.app.domain.user.repository.UserRepository;
 import com.grepp.funfun.app.domain.user.vo.UserStatus;
 import com.grepp.funfun.app.infra.error.exceptions.CommonException;
 import com.grepp.funfun.app.infra.response.ResponseCode;
-import com.grepp.funfun.app.delete.util.ReferencedWarning;
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -49,6 +52,8 @@ public class GroupService {
     private final CalendarRepository calendarRepository;
     private final GroupHashtagRepository groupHashtagRepository;
     private final CalendarService calendarService;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final S3FileService s3FileService;
 
 
     // 모든 모임 조회
@@ -58,18 +63,53 @@ public class GroupService {
             .map(this::convertToGroupResponse)
             .toList();
     }
+
     // 모임 상세 조회
     @Transactional(readOnly = true)
-    public GroupResponse get(final Long groupId) {
+    public GroupResponse get(final Long groupId, String userEmail) {
+        increaseViewCountIfNotCounted(groupId, userEmail);
         return groupRepository.findByIdWithFullInfo(groupId)
             .map(this::convertToGroupResponse)
             .orElseThrow(() -> new CommonException(ResponseCode.NOT_FOUND));
     }
 
-    //모임 조회(최신순)
+    //조회수 redis[중복 방지]
+    public void increaseViewCountIfNotCounted(Long groupId, String userEmail) {
+
+        if (userEmail == null || userEmail.trim().isEmpty()) {
+            return;
+        }
+
+        String key = "group:viewCount:" + groupId + ":user:" + userEmail;
+
+        boolean isCounted = redisTemplate.hasKey(key);
+        if (!isCounted) {
+            // 조회수 증가
+            redisTemplate.opsForValue().increment("group:" + groupId + ":viewCount");
+
+            // 현재 시간
+            LocalDateTime now = LocalDateTime.now();
+
+            // 다음 자정
+            LocalDateTime nextMidnight = now.toLocalDate().plusDays(1).atStartOfDay();
+
+            // 자정까지 남은 초
+            long secondsUntilMidnight = Duration.between(now, nextMidnight).getSeconds();
+
+            // 자정까지 TTL 설정
+            redisTemplate.opsForValue().set(key, "1", Duration.ofSeconds(secondsUntilMidnight));
+        }
+    }
+
+    // 모임 조회
     @Transactional(readOnly = true)
-    public List<GroupResponse> getRecentGroups(){
-        return groupRepository.findActiveRecentGroups().stream()
+    public List<GroupResponse> getGroups(
+        String category,
+        String keyword,
+        String sortBy,
+        String userEmail
+    ) {
+        return groupRepository.findGroups(category, keyword, sortBy, userEmail).stream()
             .map(this::convertToGroupResponse)
             .collect(Collectors.toList());
     }
@@ -82,45 +122,23 @@ public class GroupService {
             .collect(Collectors.toList());
     }
 
-    // 모임 조회(가까운 순)
-    @Transactional(readOnly = true)
-    public List<GroupResponse> findNearGroups(String userEmail) {
-
-        User user = userRepository.findByEmail(userEmail);
-        if (user == null) throw new CommonException(ResponseCode.NOT_FOUND);
-
-        return groupRepository.findNearbyGroups(user.getLatitude(),user.getLongitude()).stream()
-            .map(this::convertToGroupResponse)
-            .collect(Collectors.toList());
-    }
-
-
-    // 모임 조회(키워드)
-    @Transactional(readOnly = true)
-    public List<GroupResponse> findByKeyword(String keyword) {
-
-        return groupRepository.findGroupsByKeyword(keyword).stream()
-            .map(this::convertToGroupResponse)
-            .collect(Collectors.toList());
-    }
-
     // 모임 생성
     @Transactional
     public void create(String leaderEmail, GroupRequest request) {
 
-        User leader = userRepository.findByEmail(leaderEmail);
-
-        if (leader == null) throw new CommonException(ResponseCode.NOT_FOUND);
-        if(leader.getStatus() == UserStatus.SUSPENDED || leader.getStatus() == UserStatus.BANNED) {
-            throw new CommonException(ResponseCode.UNAUTHORIZED);
+        User leader = validateUser(leaderEmail);
+        // S3에 이미지 업로드
+        String imageUrl = null;
+        if (request.getImage() != null && !request.getImage().isEmpty()) {
+            imageUrl = s3FileService.upload(request.getImage(), "groups");
         }
-        Group savedGroup = groupRepository.save(request.toEntity(leader));
+
+        Group savedGroup = groupRepository.save(request.mapToCreate(leader, imageUrl));
 
         // 해시태그
         if (request.getHashTags() != null && !request.getHashTags().isEmpty()) {
             List<GroupHashtag> hashTags = request.getHashTags().stream()
                 .map(tagName -> {
-                    System.out.println("저장할 태그: '" + tagName + "'"); // 이것도 추가
                     GroupHashtag hashTag = new GroupHashtag();
                     hashTag.setTag(tagName);
                     hashTag.setGroup(savedGroup);
@@ -143,7 +161,7 @@ public class GroupService {
         GroupChatRoom groupChatRoom = GroupChatRoom.builder()
             .groupId(savedGroup.getId())
             .status(ChatRoomType.GROUP_CHAT)
-            .name(savedGroup.getId()+"번 그룹 채팅방")
+            .name(savedGroup.getId() + "번 그룹 채팅방")
             .build();
 
         groupChatRoomRepository.save(groupChatRoom);
@@ -155,46 +173,33 @@ public class GroupService {
     // 모임 수정
     @Transactional
     public void update(Long groupId, String leaderEmail, GroupRequest updateRequest) {
-        Group group = groupWithLeaderValidation(groupId, leaderEmail);
+        Group group = validateGroupWithLeader(groupId,leaderEmail);
 
-        //Builder 패턴으로 내용 수정하고 다시 저장하기
-        group.setTitle(updateRequest.getTitle());
-        group.setExplain(updateRequest.getExplain());
-        group.setSimpleExplain(updateRequest.getSimpleExplain());
-        group.setPlaceName(updateRequest.getPlaceName());
-        group.setGroupDate(updateRequest.getGroupDate());
-        group.setAddress(updateRequest.getAddress());
-        group.setCategory(updateRequest.getCategory());
-        group.setMaxPeople(updateRequest.getMaxPeople());
-        group.setLatitude(updateRequest.getLatitude());
-        group.setLongitude(updateRequest.getLongitude());
-        group.setDuring(updateRequest.getDuring());
+        // 이미지 변경
+        String newImageUrl = null;
+        if (updateRequest.getImage() != null && !updateRequest.getImage().isEmpty()) {
+            newImageUrl = s3FileService.upload(updateRequest.getImage(), "groups");
+        }
 
-        // 재설정
-        group.getHashtags().clear();
-        List<GroupHashtag> hashtags = updateRequest.getHashTags().stream()
-            .map(hashtagName -> GroupHashtag.builder()
-                .tag(hashtagName)
-                .group(group)
-                .build())
-            .collect(Collectors.toList());
-        group.setHashtags(hashtags);
+        // 모임 변경 사항 저장
+        Group updatedGroup = updateRequest.mapToUpdate(group, newImageUrl);
+        Group savedGroup = groupRepository.save(updatedGroup);
 
+        // 해시태그 설정
+        updateHashtags(savedGroup, updateRequest.getHashTags());
     }
 
     // 모임 삭제
     @Transactional
     public void delete(Long groupId, String leaderEmail) {
-        Group group = groupWithLeaderValidation(groupId, leaderEmail);
+        Group group = validateGroupWithLeader(groupId,leaderEmail);
 
         // 소프트 삭제 방식으로 -> false / DELETE 로 변경
-        group.unActivated();
-        group.setStatus(GroupStatus.DELETE);
+        group.changeStatusAndActivated(GroupStatus.DELETE);
 
         // 관련 멤버들 active - false / status - GROUP_DELETED
         for (Participant participant : group.getParticipants()) {
-            participant.unActivated();
-            participant.setStatus(ParticipantStatus.GROUP_DELETED);
+            participant.changeStatusAndActivated(ParticipantStatus.GROUP_DELETED);
         }
 
         // 해당 모임 id 의 일정들 삭제
@@ -204,16 +209,14 @@ public class GroupService {
     //모임 취소
     @Transactional
     public void cancel(Long groupId, String leaderEmail) {
-        Group group = groupWithLeaderValidation(groupId, leaderEmail);
+        Group group = validateGroupWithLeader(groupId,leaderEmail);
 
         // 소프트 삭제 방식으로 -> false / CANCEL 로 변경
-        group.unActivated();
-        group.setStatus(GroupStatus.CANCELED);
+        group.changeStatusAndActivated(GroupStatus.CANCELED);
 
         // 관련 멤버들 active - false / status - GROUP_CANCELED
         for (Participant participant : group.getParticipants()) {
-            participant.unActivated();
-            participant.setStatus(ParticipantStatus.GROUP_CANCELED);
+            participant.changeStatusAndActivated(ParticipantStatus.GROUP_CANCELED);
         }
 
         // 해당 모임 id 의 일정들 삭제
@@ -223,14 +226,13 @@ public class GroupService {
     // 모임 완료
     @Transactional
     public void complete(Long groupId, String leaderEmail) {
-        Group group = groupWithLeaderValidation(groupId, leaderEmail);
+        Group group = validateGroupWithLeader(groupId,leaderEmail);
 
         if (!Arrays.asList(GroupStatus.FULL, GroupStatus.RECRUITING).contains(group.getStatus())) {
             throw new IllegalStateException("완료할 수 없는 모임 상태입니다.");
         }
 
-        group.unActivated();
-        group.setStatus(GroupStatus.COMPLETED);
+        group.changeStatusAndActivated(GroupStatus.COMPLETED);
 
         // 관련 멤버들 active - false / status - GROUP_CANCELED
         for (Participant participant : group.getParticipants()) {
@@ -239,23 +241,36 @@ public class GroupService {
         }
 
     }
-    // 그룹에 리더이자 사용자 false 상태 확인 코드(중복 코드 대체)
-    //todo 검증 코드
-    private Group groupWithLeaderValidation(Long groupId, String leaderEmail) {
-        // 그룹 존재 확인
-        Group group = groupRepository.findById(groupId)
-            .orElseThrow(() -> new CommonException(ResponseCode.NOT_FOUND));
 
-        // 리더인지 확인
-        User leader = group.getLeader();
-        if (!leader.getEmail().equals(leaderEmail)) {
+    // 그룹 확인 및 사용자 검증
+    private Group validateGroupWithLeader(Long groupId, String userEmail) {
+        Group group = validateGroup(groupId);
+        User user = validateUser(userEmail);
+
+        if (!group.getLeader().getEmail().equals(user.getEmail())) {
             throw new CommonException(ResponseCode.UNAUTHORIZED);
         }
-        // 사용자로 false (정지 당한 사람이 아닌지)
-        if (leader.getStatus() == UserStatus.SUSPENDED || leader.getStatus() == UserStatus.BANNED) {
-            throw new CommonException(ResponseCode.UNAUTHORIZED);
-        }
+
         return group;
+    }
+
+    // 그룹 존재 확인
+    private Group validateGroup(Long groupId) {
+        return groupRepository.findById(groupId)
+            .orElseThrow(() -> new CommonException(ResponseCode.NOT_FOUND));
+    }
+
+    // 사용자 검증
+    private User validateUser(String userEmail) {
+        User user = userRepository.findByEmail(userEmail);
+        if (user == null) {
+            throw new CommonException(ResponseCode.NOT_FOUND);
+        }
+
+        if (user.getStatus() == UserStatus.SUSPENDED || user.getStatus() == UserStatus.BANNED) {
+            throw new CommonException(ResponseCode.UNAUTHORIZED);
+        }
+        return user;
     }
 
     private GroupMyResponse convertToGroupMyResponse(Group group, String userEmail) {
@@ -294,6 +309,20 @@ public class GroupService {
         return groupRepository.countByLeaderEmailAndStatus(email, GroupStatus.COMPLETED);
     }
 
+    private void updateHashtags(Group group, List<String> newHashTags) {
+        groupHashtagRepository.deleteByGroup(group);
+
+        if (newHashTags != null && !newHashTags.isEmpty()) {
+            List<GroupHashtag> hashtags = newHashTags.stream()
+                .map(tagName -> GroupHashtag.builder()
+                    .tag(tagName)
+                    .group(group)
+                    .build())
+                .collect(Collectors.toList());
+            groupHashtagRepository.saveAll(hashtags);
+        }
+    }
+
     private GroupResponse convertToGroupResponse(Group group) {
         return GroupResponse.builder()
             .id(group.getId())
@@ -303,6 +332,8 @@ public class GroupService {
             .placeName(group.getPlaceName())
             .address(group.getAddress())
             .groupDate(group.getGroupDate())
+            .createdAt(group.getCreatedAt())
+            .viewCount(group.getViewCount())
             .maxPeople(group.getMaxPeople())
             .nowPeople(group.getNowPeople())
             .status(group.getStatus())
@@ -316,26 +347,6 @@ public class GroupService {
                 .map(GroupHashtag::getTag)
                 .collect(Collectors.toList()))
             .build();
-    }
-
-    private Group mapToEntity(final GroupDTO groupDTO, final Group group) {
-        group.setTitle(groupDTO.getTitle());
-        group.setExplain(groupDTO.getExplain());
-        group.setPlaceName(groupDTO.getPlaceName());
-        group.setAddress(groupDTO.getAddress());
-        group.setGroupDate(groupDTO.getGroupDate());
-        group.setMaxPeople(groupDTO.getMaxPeople());
-        group.setNowPeople(groupDTO.getNowPeople());
-        group.setStatus(groupDTO.getStatus());
-        group.setLatitude(groupDTO.getLatitude());
-        group.setLongitude(groupDTO.getLongitude());
-        group.setDuring(groupDTO.getDuring());
-        group.setCategory(groupDTO.getCategory());
-        final User leader =
-            groupDTO.getLeader() == null ? null : userRepository.findById(groupDTO.getLeader())
-                .orElseThrow(() -> new CommonException(ResponseCode.NOT_FOUND));
-        group.setLeader(leader);
-        return group;
     }
 
     public ReferencedWarning getReferencedWarning(final Long id) {

--- a/src/main/java/com/grepp/funfun/app/domain/group/service/GroupService.java
+++ b/src/main/java/com/grepp/funfun/app/domain/group/service/GroupService.java
@@ -122,6 +122,14 @@ public class GroupService {
             .collect(Collectors.toList());
     }
 
+    // 내가 리더인 모임 조회
+    @Transactional(readOnly = true)
+    public List<GroupResponse> findMyLeaderGroups(String userEmail) {
+        return groupRepository.findByLeaderEmail(userEmail).stream()
+            .map(this::convertToGroupResponse)
+            .collect(Collectors.toList());
+    }
+
     // 모임 생성
     @Transactional
     public void create(String leaderEmail, GroupRequest request) {
@@ -342,7 +350,8 @@ public class GroupService {
             .during(group.getDuring())
             .category(group.getCategory())
             .activated(group.getActivated())
-            .leader(group.getLeader().getNickname())
+            .leaderNickname(group.getLeader().getNickname())
+            .leaderEmail(group.getLeader().getEmail())
             .hashTags(group.getHashtags().stream()
                 .map(GroupHashtag::getTag)
                 .collect(Collectors.toList()))

--- a/src/main/java/com/grepp/funfun/app/domain/participant/entity/Participant.java
+++ b/src/main/java/com/grepp/funfun/app/domain/participant/entity/Participant.java
@@ -47,4 +47,9 @@ public class Participant extends BaseEntity {
     @JoinColumn(name = "group_id", nullable = false)
     private Group group;
 
+    public void changeStatusAndActivated(ParticipantStatus status) {
+        this.unActivated();
+        this.status = status;
+    }
+
 }

--- a/src/main/java/com/grepp/funfun/app/domain/participant/service/ParticipantService.java
+++ b/src/main/java/com/grepp/funfun/app/domain/participant/service/ParticipantService.java
@@ -218,8 +218,7 @@ public class ParticipantService {
         Participant participant = participantRepository.findTrueMember(groupId,userEmail)
             .orElseThrow(()-> new CommonException(ResponseCode.NOT_FOUND));
 
-        // 3. 모임 나가기 : 비활성화 처리 + LEAVE 처리
-        participant.unActivated();
+        // 3. 모임 나가기 : LEAVE 처리
         participant.setStatus(ParticipantStatus.LEAVE);
 
         group.setNowPeople(group.getNowPeople() - 1);


### PR DESCRIPTION
## 📌 과제 설명 
feat: 조회수 스케줄러 생성
feat: 모임 정렬 (하나의 기능으로 통합)
feat: 조회수 조회,추가 기능
feat: 내가 리더인 모임 조회

## 👩‍💻 요구 사항과 구현 내용
내가 리더인 모임만 조회하는 기능 추가했습니다. 
조회수 -> redis로 구현하고 스케줄러를 통해 현재는 1분마다 db 값(viewCount) 업데이트하는 방식으로 구현했습니다.
조회수 과정에서 userEmail 값도 레디스로 넘겨서 24시간 기준으로 한번만 조회수 증가(조회수 중복 증가 방지 했습니다.)
모임 정렬
- 최신순 : 생성일 기준
- 거리순 : userEmail 값이 없을 경우(비회원) -> 최신순으로
- 조회순 : db viewCount 기준
- default : 거리순 
- 
현재 코드를 멘토님 피드백을 바탕으로 group쪽은 set 사용하지 않고, builder 패턴과 메서드화 해서 리팩토링 했습니다.


