### PR TITLE
feat: OAuth2 변경, 회원 정보 수정 기능 구현

### DIFF
--- a/src/main/java/com/grepp/funfun/app/domain/auth/controller/AuthApiController.java
+++ b/src/main/java/com/grepp/funfun/app/domain/auth/controller/AuthApiController.java
@@ -4,8 +4,10 @@ import com.grepp.funfun.app.domain.auth.payload.LoginRequest;
 import com.grepp.funfun.app.domain.auth.payload.TokenResponse;
 import com.grepp.funfun.app.domain.auth.service.AuthService;
 import com.grepp.funfun.app.domain.auth.dto.TokenDto;
+import com.grepp.funfun.app.domain.preference.service.PreferenceService;
 import com.grepp.funfun.app.infra.auth.jwt.TokenCookieFactory;
 import com.grepp.funfun.app.infra.response.ApiResponse;
+import com.grepp.funfun.app.infra.response.ResponseCode;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -24,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthApiController {
     
     private final AuthService authService;
+    private final PreferenceService preferenceService;
     
     @PostMapping("/login")
     @Operation(summary = "로그인", description = "로그인 성공 시 AccessToken 쿠키와 RefreshToken 쿠키를 발급합니다.")
@@ -33,6 +36,11 @@ public class AuthApiController {
     ) {
         TokenDto tokenDto = authService.signin(loginRequest);
         TokenCookieFactory.setAllAuthCookies(response, tokenDto);
+
+        // 취향 설정을 하지 않은 사용자
+        if (!preferenceService.hasPreferences(loginRequest.getEmail())) {
+            return ResponseEntity.ok(ApiResponse.error(ResponseCode.USER_PREFERENCE_NOT_SET));
+        }
 
         return ResponseEntity.ok(ApiResponse.success(TokenResponse.builder().
                                                          accessToken(tokenDto.getAccessToken())

--- a/src/main/java/com/grepp/funfun/app/domain/preference/service/PreferenceService.java
+++ b/src/main/java/com/grepp/funfun/app/domain/preference/service/PreferenceService.java
@@ -82,4 +82,8 @@ public class PreferenceService {
             .build();
     }
 
+    public boolean hasPreferences(String email) {
+        return !contentPreferenceRepository.findByUserEmail(email).isEmpty()
+            && !groupPreferenceRepository.findByUserEmail(email).isEmpty();
+    }
 }

--- a/src/main/java/com/grepp/funfun/app/domain/user/controller/UserApiController.java
+++ b/src/main/java/com/grepp/funfun/app/domain/user/controller/UserApiController.java
@@ -3,7 +3,7 @@ package com.grepp.funfun.app.domain.user.controller;
 import com.grepp.funfun.app.domain.auth.payload.TokenResponse;
 import com.grepp.funfun.app.domain.user.dto.payload.ChangePasswordRequest;
 import com.grepp.funfun.app.domain.user.dto.payload.NicknameRequest;
-import com.grepp.funfun.app.domain.user.dto.payload.OAuth2SignupRequest;
+import com.grepp.funfun.app.domain.user.dto.payload.UserInfoRequest;
 import com.grepp.funfun.app.domain.user.dto.payload.SignupRequest;
 import com.grepp.funfun.app.domain.user.dto.payload.UserInfoResponse;
 import com.grepp.funfun.app.domain.user.dto.payload.VerifyCodeRequest;
@@ -29,6 +29,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -58,12 +59,12 @@ public class UserApiController {
         return ResponseEntity.ok(ApiResponse.success(userService.getUserInfo(email)));
     }
 
-    @PatchMapping("/signup/oauth2")
-    @Operation(summary = "OAuth2 회원가입", description = "소셜 로그인 대상의 추가 정보를 입력 받습니다.")
-    public ResponseEntity<ApiResponse<String>> updateOAuth2User(@RequestBody @Valid OAuth2SignupRequest request, Authentication authentication) {
+    @PutMapping("/info")
+    @Operation(summary = "회원 정보 수정", description = "회원 정보를 수정합니다.")
+    public ResponseEntity<ApiResponse<String>> updateUser(@RequestBody @Valid UserInfoRequest request, Authentication authentication) {
         String email = authentication.getName();
-        userService.updateOAuth2User(email, request);
-        return ResponseEntity.ok(ApiResponse.success(email));
+        userService.updateUserInfo(email, request);
+        return ResponseEntity.ok(ApiResponse.success("회원 정보 수정했습니다."));
     }
 
     @PatchMapping

--- a/src/main/java/com/grepp/funfun/app/domain/user/controller/UserApiController.java
+++ b/src/main/java/com/grepp/funfun/app/domain/user/controller/UserApiController.java
@@ -5,6 +5,7 @@ import com.grepp.funfun.app.domain.user.dto.payload.ChangePasswordRequest;
 import com.grepp.funfun.app.domain.user.dto.payload.NicknameRequest;
 import com.grepp.funfun.app.domain.user.dto.payload.OAuth2SignupRequest;
 import com.grepp.funfun.app.domain.user.dto.payload.SignupRequest;
+import com.grepp.funfun.app.domain.user.dto.payload.UserInfoResponse;
 import com.grepp.funfun.app.domain.user.dto.payload.VerifyCodeRequest;
 import com.grepp.funfun.app.domain.auth.vo.AuthToken;
 import com.grepp.funfun.app.domain.auth.dto.TokenDto;
@@ -24,6 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -47,6 +49,13 @@ public class UserApiController {
     public ResponseEntity<ApiResponse<String>> createUser(@RequestBody @Valid SignupRequest request) {
         String createdEmail = userService.create(request);
         return ResponseEntity.ok(ApiResponse.success(createdEmail));
+    }
+
+    @GetMapping("/info")
+    @Operation(summary = "회원 정보 조회", description = "회원 정보를 조회합니다.")
+    public ResponseEntity<ApiResponse<UserInfoResponse>> getUser(Authentication authentication) {
+        String email = authentication.getName();
+        return ResponseEntity.ok(ApiResponse.success(userService.getUserInfo(email)));
     }
 
     @PatchMapping("/signup/oauth2")

--- a/src/main/java/com/grepp/funfun/app/domain/user/controller/UserApiController.java
+++ b/src/main/java/com/grepp/funfun/app/domain/user/controller/UserApiController.java
@@ -126,7 +126,7 @@ public class UserApiController {
     }
 
     @PatchMapping("/change/nickname")
-    @Operation(summary = "닉네임 변경", description = "인증 코드로 인증된 사용자에 한해서 닉네임 변경을 진행합니다.")
+    @Operation(summary = "닉네임 변경", description = "닉네임 변경을 합니다.")
     public ResponseEntity<ApiResponse<String>> changeNickname(@RequestBody @Valid
     NicknameRequest request, Authentication authentication) {
         String email = authentication.getName();

--- a/src/main/java/com/grepp/funfun/app/domain/user/dto/payload/UserInfoRequest.java
+++ b/src/main/java/com/grepp/funfun/app/domain/user/dto/payload/UserInfoRequest.java
@@ -1,9 +1,7 @@
 package com.grepp.funfun.app.domain.user.dto.payload;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.grepp.funfun.app.domain.auth.vo.Role;
 import com.grepp.funfun.app.domain.user.vo.Gender;
-import com.grepp.funfun.app.domain.user.entity.User;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -13,13 +11,16 @@ import java.time.format.DateTimeParseException;
 import lombok.Data;
 
 @Data
-public class OAuth2SignupRequest {
-
-    @NotBlank(message = "닉네임은 필수입니다.")
-    private String nickname;
+public class UserInfoRequest {
 
     @NotBlank(message = "주소는 필수입니다.")
     private String address;
+
+    @NotNull(message = "위도는 필수입니다.")
+    private Double latitude;
+
+    @NotNull(message = "경도는 필수입니다.")
+    private Double longitude;
 
     @NotBlank(message = "생년월일은 필수입니다.")
     private String birthDate;
@@ -40,13 +41,4 @@ public class OAuth2SignupRequest {
     @NotNull(message = "마케팅 수신 여부를 선택해주세요.")
     @JsonProperty("isMarketingAgreed")
     private Boolean isMarketingAgreed;
-
-    public void toEntity(User user) {
-        user.setNickname(nickname);
-        user.setAddress(address);
-        user.setBirthDate(birthDate);
-        user.setGender(gender);
-        user.setIsMarketingAgreed(isMarketingAgreed);
-        user.setRole(Role.ROLE_USER);
-    }
 }

--- a/src/main/java/com/grepp/funfun/app/domain/user/dto/payload/UserInfoResponse.java
+++ b/src/main/java/com/grepp/funfun/app/domain/user/dto/payload/UserInfoResponse.java
@@ -1,0 +1,40 @@
+package com.grepp.funfun.app.domain.user.dto.payload;
+
+import com.grepp.funfun.app.domain.user.entity.User;
+import com.grepp.funfun.app.domain.user.vo.Gender;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class UserInfoResponse {
+
+    private String email;
+
+    private String nickname;
+
+    private String address;
+
+    private Double latitude;
+
+    private Double longitude;
+
+    private String birthDate;
+
+    private Gender gender;
+
+    private Boolean isMarketingAgreed;
+
+    public static UserInfoResponse from(User user) {
+        return UserInfoResponse.builder()
+            .email(user.getEmail())
+            .nickname(user.getNickname())
+            .address(user.getAddress())
+            .latitude(user.getLatitude())
+            .longitude(user.getLongitude())
+            .birthDate(user.getBirthDate())
+            .gender(user.getGender())
+            .isMarketingAgreed(user.getIsMarketingAgreed())
+            .build();
+    }
+}

--- a/src/main/java/com/grepp/funfun/app/domain/user/entity/User.java
+++ b/src/main/java/com/grepp/funfun/app/domain/user/entity/User.java
@@ -3,6 +3,7 @@ package com.grepp.funfun.app.domain.user.entity;
 import com.grepp.funfun.app.domain.auth.vo.Role;
 import com.grepp.funfun.app.domain.preference.entity.ContentPreference;
 import com.grepp.funfun.app.domain.preference.entity.GroupPreference;
+import com.grepp.funfun.app.domain.user.dto.payload.UserInfoRequest;
 import com.grepp.funfun.app.domain.user.vo.Gender;
 import com.grepp.funfun.app.domain.user.vo.UserStatus;
 import com.grepp.funfun.app.infra.entity.BaseEntity;
@@ -78,4 +79,17 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user")
     private List<ContentPreference> contentPreferences = new ArrayList<>();
 
+    public void updateFromRequest(UserInfoRequest request) {
+        this.address = request.getAddress();
+        this.latitude = request.getLatitude();
+        this.longitude = request.getLongitude();
+        this.birthDate = request.getBirthDate();
+        this.gender = request.getGender();
+        this.isMarketingAgreed = request.getIsMarketingAgreed();
+
+        // OAuth2 사용자가 추가 정보 기입 완료하면 ROLE_USER 로 전환
+        if (this.role == Role.ROLE_GUEST) {
+            this.role = Role.ROLE_USER;
+        }
+    }
 }

--- a/src/main/java/com/grepp/funfun/app/domain/user/service/UserService.java
+++ b/src/main/java/com/grepp/funfun/app/domain/user/service/UserService.java
@@ -240,13 +240,7 @@ public class UserService {
 
     @Transactional
     public void changeNickname(String email, String nickname) {
-        String verifiedKey = "auth-code:verified:" +  email;
-        String coolDownKey = "auth-cooldown:code:" +  email;
         User user = userRepository.findById(email).orElseThrow(() -> new CommonException(ResponseCode.NOT_FOUND));
-
-        if (!redisTemplate.hasKey(verifiedKey)) {
-            throw new CommonException(ResponseCode.BAD_REQUEST);
-        }
 
         // 닉네임 중복 검사
         if (userRepository.existsByNickname(nickname)) {
@@ -255,11 +249,6 @@ public class UserService {
 
         user.setNickname(nickname);
         userRepository.save(user);
-
-        // 레디스 인증 키 삭제
-        redisTemplate.delete(verifiedKey);
-        // 레디스 메일 쿨타임 키 삭제
-        redisTemplate.delete(coolDownKey);
     }
 
     public void verifyNickname(String nickname) {

--- a/src/main/java/com/grepp/funfun/app/domain/user/service/UserService.java
+++ b/src/main/java/com/grepp/funfun/app/domain/user/service/UserService.java
@@ -22,6 +22,7 @@ import com.grepp.funfun.app.domain.social.entity.Message;
 import com.grepp.funfun.app.domain.social.repository.FollowRepository;
 import com.grepp.funfun.app.domain.social.repository.MessageRepository;
 import com.grepp.funfun.app.domain.user.dto.UserDTO;
+import com.grepp.funfun.app.domain.user.dto.payload.UserInfoResponse;
 import com.grepp.funfun.app.domain.user.entity.User;
 import com.grepp.funfun.app.domain.user.entity.UserInfo;
 import com.grepp.funfun.app.domain.user.repository.UserInfoRepository;
@@ -79,6 +80,12 @@ public class UserService {
     public UserDTO get(final String email) {
         return userRepository.findById(email)
             .map(user -> mapToDTO(user, new UserDTO()))
+            .orElseThrow(() -> new CommonException(ResponseCode.NOT_FOUND));
+    }
+
+    public UserInfoResponse getUserInfo(String email) {
+        return userRepository.findById(email)
+            .map(UserInfoResponse::from)
             .orElseThrow(() -> new CommonException(ResponseCode.NOT_FOUND));
     }
 

--- a/src/main/java/com/grepp/funfun/app/domain/user/service/UserService.java
+++ b/src/main/java/com/grepp/funfun/app/domain/user/service/UserService.java
@@ -1,6 +1,6 @@
 package com.grepp.funfun.app.domain.user.service;
 
-import com.grepp.funfun.app.domain.user.dto.payload.OAuth2SignupRequest;
+import com.grepp.funfun.app.domain.user.dto.payload.UserInfoRequest;
 import com.grepp.funfun.app.domain.user.dto.payload.SignupRequest;
 import com.grepp.funfun.app.domain.auth.service.AuthService;
 import com.grepp.funfun.app.domain.auth.dto.TokenDto;
@@ -235,14 +235,10 @@ public class UserService {
     }
 
     @Transactional
-    public void updateOAuth2User(String email, OAuth2SignupRequest request) {
+    public void updateUserInfo(String email, UserInfoRequest request) {
         User user = userRepository.findById(email).orElseThrow(() -> new CommonException(ResponseCode.NOT_FOUND));
-        // 닉네임 중복 검사
-        if (userRepository.existsByNickname(request.getNickname())) {
-            throw new CommonException(ResponseCode.USER_NICKNAME_DUPLICATE);
-        }
-        request.toEntity(user);
-        userRepository.save(user);
+
+        user.updateFromRequest(request);
     }
 
     @Transactional

--- a/src/main/java/com/grepp/funfun/app/infra/auth/jwt/filter/LogoutFilter.java
+++ b/src/main/java/com/grepp/funfun/app/infra/auth/jwt/filter/LogoutFilter.java
@@ -1,9 +1,11 @@
 package com.grepp.funfun.app.infra.auth.jwt.filter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.grepp.funfun.app.domain.auth.vo.AuthToken;
 import com.grepp.funfun.app.domain.auth.token.RefreshTokenService;
 import com.grepp.funfun.app.infra.auth.jwt.JwtTokenProvider;
 import com.grepp.funfun.app.infra.auth.jwt.TokenCookieFactory;
+import com.grepp.funfun.app.infra.response.ApiResponse;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -11,41 +13,44 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @Component
 @RequiredArgsConstructor
 public class LogoutFilter extends OncePerRequestFilter {
-    
+
     private final RefreshTokenService refreshTokenService;
     private final JwtTokenProvider jwtTokenProvider;
+    private final ObjectMapper objectMapper;
 
-    @Value("${front-server.domain}")
-    private String front;
-    
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
         FilterChain filterChain) throws ServletException, IOException {
-        
+
         String accessToken = jwtTokenProvider.resolveToken(request, AuthToken.ACCESS_TOKEN);
-        
+
         if(accessToken == null){
             filterChain.doFilter(request,response);
             return;
         }
-        
+
         String path = request.getRequestURI();
         Claims claims  = jwtTokenProvider.getClaims(accessToken);
-        
+
         if(path.equals("/auth/logout")){
             refreshTokenService.deleteByAccessTokenId(claims.getId());
             TokenCookieFactory.setAllExpiredCookies(response);
-            // NOTE: 프론트 측 URI 로 변경 필요
-            response.sendRedirect(front + "/");
+
+            response.setStatus(HttpServletResponse.SC_OK);
+            response.setContentType("application/json;charset=UTF-8");
+
+            ApiResponse<String> result = ApiResponse.success("로그아웃 성공");
+            response.getWriter().write(objectMapper.writeValueAsString(result));
+
+            return;
         }
-        
+
         filterChain.doFilter(request,response);
     }
 }

--- a/src/main/java/com/grepp/funfun/app/infra/auth/oauth2/OAuth2FailureHandler.java
+++ b/src/main/java/com/grepp/funfun/app/infra/auth/oauth2/OAuth2FailureHandler.java
@@ -1,11 +1,14 @@
 package com.grepp.funfun.app.infra.auth.oauth2;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.grepp.funfun.app.infra.response.ApiResponse;
+import com.grepp.funfun.app.infra.response.ResponseCode;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
@@ -13,23 +16,30 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
+@RequiredArgsConstructor
 public class OAuth2FailureHandler implements AuthenticationFailureHandler {
 
-    @Value("${front-server.domain}")
-    private String front;
+    private final ObjectMapper objectMapper;
 
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
         AuthenticationException exception) throws IOException, ServletException {
 
         String errorCode = "oauth2_authentication_error"; // 기본값
+        String description = "OAuth2 인증 중 알 수 없는 오류가 발생했습니다.";
 
         if (exception instanceof OAuth2AuthenticationException oae) {
             errorCode = oae.getError().getErrorCode();
-            log.warn("OAuth2 로그인 실패: {}", oae.getError().getDescription());
+            description = oae.getError().getDescription();
+            log.warn("OAuth2 로그인 실패 - code: {}, description: {}", errorCode, description);
+        } else {
+            log.warn("OAuth2 로그인 실패 - 예외: {}", exception.getMessage());
         }
 
-        // NOTE : 프론트 측 URI 로 변경 필요
-        response.sendRedirect(front + "/login/oauth2/error?reason=" + errorCode);
+        ApiResponse<Void> errorResponse = ApiResponse.error(ResponseCode.OAUTH2_AUTHENTICATION_FAILED, description);
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
     }
 }

--- a/src/main/java/com/grepp/funfun/app/infra/response/ApiResponse.java
+++ b/src/main/java/com/grepp/funfun/app/infra/response/ApiResponse.java
@@ -30,6 +30,6 @@ public record ApiResponse<T>(
     }
 
     public static <T> ApiResponse<T> error(ResponseCode code, T data) {
-        return new ApiResponse<>(code.code(), code.message(), null, null);
+        return new ApiResponse<>(code.code(), code.message(), null, data);
     }
 }

--- a/src/main/java/com/grepp/funfun/app/infra/response/ResponseCode.java
+++ b/src/main/java/com/grepp/funfun/app/infra/response/ResponseCode.java
@@ -16,11 +16,14 @@ public enum ResponseCode {
     ALREADY_VERIFIED("4016", HttpStatus.BAD_REQUEST, "이미 인증된 사용자입니다."),
     USER_NOT_VERIFY("4017", HttpStatus.BAD_REQUEST, "이메일 인증이 되지 않은 사용자입니다"),
     USER_SUSPENDED("4018", HttpStatus.BAD_REQUEST, "일시정지된 사용자입니다."),
-    USER_BANNED("4022", HttpStatus.BAD_REQUEST, "영구정지된 사용자입니다."),
     USER_INACTIVE("4019", HttpStatus.BAD_REQUEST, "비활성화된 사용자입니다."),
     INVALID_AUTH_CODE("4020", HttpStatus.BAD_REQUEST, "잘못된 인증 코드입니다."),
-    ALREADY_EXISTS("4021", HttpStatus.BAD_REQUEST, "중복된 데이터가 존재합니다."),
     TOO_FAST_VERIFY_REQUEST("4021", HttpStatus.BAD_REQUEST, "인증 메일은 3분마다 발송할 수 있습니다."),
+    USER_BANNED("4022", HttpStatus.BAD_REQUEST, "영구정지된 사용자입니다."),
+    ALREADY_EXISTS("4023", HttpStatus.BAD_REQUEST, "중복된 데이터가 존재합니다."),
+    USER_GUEST("4024", HttpStatus.OK, "추가 회원가입이 필요한 OAuth2 사용자입니다."),
+    USER_PREFERENCE_NOT_SET("4025", HttpStatus.OK, "사용자의 선호 취향이 아직 설정되지 않았습니다."),
+    OAUTH2_AUTHENTICATION_FAILED("4026", HttpStatus.UNAUTHORIZED, "OAuth2 로그인에 실패했습니다."),
     INTERNAL_SERVER_ERROR("5000", HttpStatus.INTERNAL_SERVER_ERROR, "서버에러 입니다."),
     SECURITY_INCIDENT("6000", HttpStatus.OK, "비정상적인 로그인 시도가 감지되었습니다.");
     

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1522,34 +1522,34 @@ INSERT INTO "user" (email, password, nickname, birth_date, gender, address, lati
                     role, status, due_date, suspend_duration, due_reason, is_verified,
                     is_marketing_agreed, info_id, activated, created_at, modified_at)
 VALUES
-    ('t1@aaa.aaa', '{bcrypt}$2a$10$ART8g5agLHIE7F4cZ.SEreokni2CuMBm6mgwg6xXhIk4eCD75P9Oa', '김철수', '1990-03-15', 'MALE', '서울특별시 강남구 역삼동 테헤란로 123', 37.5009, 127.0360,
+    ('t1@aaa.aaa', '{bcrypt}$2a$10$ART8g5agLHIE7F4cZ.SEreokni2CuMBm6mgwg6xXhIk4eCD75P9Oa', '김철수', '19900315', 'MALE', '서울특별시 강남구 역삼동 테헤란로 123', 37.5009, 127.0360,
      'ROLE_USER', 'ACTIVE', NULL, NULL, NULL, true, true, 't1@aaa.aaa', true, NOW(), NOW()),
 
-    ('t2@aaa.aaa', '{bcrypt}$2a$10$ART8g5agLHIE7F4cZ.SEreokni2CuMBm6mgwg6xXhIk4eCD75P9Oa', '이영희', '1985-07-22', 'FEMALE', '서울특별시 송파구 잠실동 올림픽로 456', 37.5133, 127.1028,
+    ('t2@aaa.aaa', '{bcrypt}$2a$10$ART8g5agLHIE7F4cZ.SEreokni2CuMBm6mgwg6xXhIk4eCD75P9Oa', '이영희', '19850722', 'FEMALE', '서울특별시 송파구 잠실동 올림픽로 456', 37.5133, 127.1028,
      'ROLE_USER', 'ACTIVE', NULL, NULL, NULL, true, false, 't2@aaa.aaa', true, NOW(), NOW()),
 
-    ('t3@aaa.aaa', '{bcrypt}$2a$10$ART8g5agLHIE7F4cZ.SEreokni2CuMBm6mgwg6xXhIk4eCD75P9Oa', '박민수', '1992-11-08', 'MALE', '서울특별시 서초구 반포동 반포대로 789', 37.5047, 127.0089,
+    ('t3@aaa.aaa', '{bcrypt}$2a$10$ART8g5agLHIE7F4cZ.SEreokni2CuMBm6mgwg6xXhIk4eCD75P9Oa', '박민수', '19921108', 'MALE', '서울특별시 서초구 반포동 반포대로 789', 37.5047, 127.0089,
      'ROLE_USER', 'ACTIVE', NULL, NULL, NULL, true, true, 't3@aaa.aaa', true, NOW(), NOW()),
 
-    ('t4@aaa.aaa', '{bcrypt}$2a$10$ART8g5agLHIE7F4cZ.SEreokni2CuMBm6mgwg6xXhIk4eCD75P9Oa', '정수빈', '1988-02-14', 'FEMALE', '서울특별시 마포구 상암동 월드컵북로 321', 37.5799, 126.8896,
+    ('t4@aaa.aaa', '{bcrypt}$2a$10$ART8g5agLHIE7F4cZ.SEreokni2CuMBm6mgwg6xXhIk4eCD75P9Oa', '정수빈', '19880214', 'FEMALE', '서울특별시 마포구 상암동 월드컵북로 321', 37.5799, 126.8896,
      'ROLE_USER', 'ACTIVE', NULL, NULL, NULL, false, true, 't4@aaa.aaa', true, NOW(), NOW()),
 
-    ('t5@aaa.aaa', '{bcrypt}$2a$10$ART8g5agLHIE7F4cZ.SEreokni2CuMBm6mgwg6xXhIk4eCD75P9Oa', '최동욱', '1993-09-30', 'MALE', '서울특별시 용산구 한남동 한남대로 654', 37.5347, 126.9990,
+    ('t5@aaa.aaa', '{bcrypt}$2a$10$ART8g5agLHIE7F4cZ.SEreokni2CuMBm6mgwg6xXhIk4eCD75P9Oa', '최동욱', '19930930', 'MALE', '서울특별시 용산구 한남동 한남대로 654', 37.5347, 126.9990,
      'ROLE_USER', 'SUSPENDED', '2025-08-15', 30, '부적절한 게시물', true, false, 't5@aaa.aaa', true, NOW(), NOW()),
 
-    ('t6@aaa.aaa', '{bcrypt}$2a$10$ART8g5agLHIE7F4cZ.SEreokni2CuMBm6mgwg6xXhIk4eCD75P9Oa', '장미라', '1987-05-03', 'FEMALE', '서울특별시 성동구 성수동 아차산로 147', 37.5447, 127.0557,
+    ('t6@aaa.aaa', '{bcrypt}$2a$10$ART8g5agLHIE7F4cZ.SEreokni2CuMBm6mgwg6xXhIk4eCD75P9Oa', '장미라', '19870503', 'FEMALE', '서울특별시 성동구 성수동 아차산로 147', 37.5447, 127.0557,
      'ROLE_USER', 'ACTIVE', NULL, NULL, NULL, true, true, 't6@aaa.aaa', true, NOW(), NOW()),
 
-    ('t7@aaa.aaa', '{bcrypt}$2a$10$ART8g5agLHIE7F4cZ.SEreokni2CuMBm6mgwg6xXhIk4eCD75P9Oa', '안준호', '1991-12-25', 'MALE', '서울특별시 강북구 수유동 도봉로 258', 37.6369, 127.0253,
+    ('t7@aaa.aaa', '{bcrypt}$2a$10$ART8g5agLHIE7F4cZ.SEreokni2CuMBm6mgwg6xXhIk4eCD75P9Oa', '안준호', '19911225', 'MALE', '서울특별시 강북구 수유동 도봉로 258', 37.6369, 127.0253,
      'ROLE_USER', 'ACTIVE', NULL, NULL, NULL, true, true, 't7@aaa.aaa', true, NOW(), NOW()),
 
-    ('t8@aaa.aaa', '{bcrypt}$2a$10$ART8g5agLHIE7F4cZ.SEreokni2CuMBm6mgwg6xXhIk4eCD75P9Oa', '오세영', '1989-08-17', 'FEMALE', '서울특별시 광진구 자양동 능동로 369', 37.5347, 127.0822,
+    ('t8@aaa.aaa', '{bcrypt}$2a$10$ART8g5agLHIE7F4cZ.SEreokni2CuMBm6mgwg6xXhIk4eCD75P9Oa', '오세영', '19890817', 'FEMALE', '서울특별시 광진구 자양동 능동로 369', 37.5347, 127.0822,
      'ROLE_USER', 'ACTIVE', NULL, NULL, NULL, false, false, 't8@aaa.aaa', true, NOW(), NOW()),
 
-    ('t9@aaa.aaa', '{bcrypt}$2a$10$ART8g5agLHIE7F4cZ.SEreokni2CuMBm6mgwg6xXhIk4eCD75P9Oa', '유하늘', '1994-04-12', 'MALE', '서울특별시 중구 을지로 을지로3가 852', 37.5661, 126.9917,
+    ('t9@aaa.aaa', '{bcrypt}$2a$10$ART8g5agLHIE7F4cZ.SEreokni2CuMBm6mgwg6xXhIk4eCD75P9Oa', '유하늘', '19940412', 'MALE', '서울특별시 중구 을지로 을지로3가 852', 37.5661, 126.9917,
      'ROLE_ADMIN', 'ACTIVE', NULL, NULL, NULL, true, true, 't9@aaa.aaa', true, NOW(), NOW()),
 
-    ('t10@aaa.aaa', '{bcrypt}$2a$10$ART8g5agLHIE7F4cZ.SEreokni2CuMBm6mgwg6xXhIk4eCD75P9Oa', '임소라', '1986-01-28', 'FEMALE', '서울특별시 동작구 상도동 상도로 741', 37.5013, 126.9486,
+    ('t10@aaa.aaa', '{bcrypt}$2a$10$ART8g5agLHIE7F4cZ.SEreokni2CuMBm6mgwg6xXhIk4eCD75P9Oa', '임소라', '19860128', 'FEMALE', '서울특별시 동작구 상도동 상도로 741', 37.5013, 126.9486,
      'ROLE_USER', 'ACTIVE', NULL, NULL, NULL, true, true, 't10@aaa.aaa', true, NOW(), NOW());
 
 INSERT INTO user_hashtag (tag, info_id)


### PR DESCRIPTION
## 📌 과제 설명
OAuth2 응답 형태 변경과 회원 정보 수정 기능 구현했습니다.
## 👩‍💻 요구 사항과 구현 내용
* OAuth2 리다이렉션 -> Json 응답 반환 수정
    * 리다이렉션 시 쿠키 저장이 정상적으로 안되는 현상을 해결하기 위해 리다이렉션 대신 Json 응답 반환
    * USER_GUEST("4024", HttpStatus.OK, "추가 회원가입이 필요한 OAuth2 사용자입니다."),
    * USER_PREFERENCE_NOT_SET("4025", HttpStatus.OK, "사용자의 선호 취향이 아직 설정되지 않았습니다."),
    * OAUTH2_AUTHENTICATION_FAILED("4026", HttpStatus.UNAUTHORIZED, "OAuth2 로그인에 실패했습니다."),
* 로그인 시 취향 설정 전인 사용자 검증
    * 취향 설정 전인 사용자는 USER_PREFERENCE_NOT_SET를 반환합니다.
    * 추후 프론트에서 이 응답에 대해 취향 설문조사 페이지로 리다이렉션 처리
* ApiResponse.error 수정
    * Validation 예외가 제대로 잡히지 않던 현상을 수정했습니다.
* 닉네임 변경 시 인증 키 검증 삭제
    * 논의 결과에 따라 닉네임 변경 시에는 인증을 별도로 진행하지 않습니다.
* 회원 정보 조회 기능
* 회원 정보 수정 기능
    * 현재는 닉네임 변경은 회원 정보 수정에서 제외됐습니다.
    * 기존 OAuth2 회원가입 기능과 통합되었습니다.
