### PR TITLE
feat: 관리자 신고 조회 및 응답, 제재 기능 구현

### DIFF
--- a/src/main/java/com/grepp/funfun/app/domain/admin/controller/AdminReportApiController.java
+++ b/src/main/java/com/grepp/funfun/app/domain/admin/controller/AdminReportApiController.java
@@ -1,0 +1,39 @@
+package com.grepp.funfun.app.domain.admin.controller;
+
+import com.grepp.funfun.app.domain.admin.dto.AdminReportViewDTO;
+import com.grepp.funfun.app.domain.admin.dto.payload.AdminReportProcessRequest;
+import com.grepp.funfun.app.domain.admin.service.AdminReportService;
+import com.grepp.funfun.app.infra.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/admin/reports")
+@RequiredArgsConstructor
+public class AdminReportApiController {
+
+    private final AdminReportService adminReportService;
+
+    @GetMapping
+    @Operation(summary = "관리자 신고 목록 조회", description = "status param으로 전체 / 처리완료 / 미처리 필터 가능 (all, resolved, unresolved)")
+    public ResponseEntity<ApiResponse<List<AdminReportViewDTO>>> getAllReports(
+            @RequestParam(defaultValue = "all") String status
+    ) {
+        List<AdminReportViewDTO> reports = adminReportService.getAllReports(status);
+        return ResponseEntity.ok(ApiResponse.success(reports));
+    }
+
+    @PatchMapping("/{id}")
+    @Operation(summary = "신고 처리", description = "신고에 대한 유저 제재 or 답변 등록 처리")
+    public ResponseEntity<ApiResponse<String>> processReport(
+            @PathVariable Long id,
+            @RequestBody AdminReportProcessRequest request
+            ){
+            adminReportService.processReport(id, request);
+            return ResponseEntity.ok(ApiResponse.success("신고가 정상적으로 처리되었습니다."));
+    }
+}

--- a/src/main/java/com/grepp/funfun/app/domain/admin/dto/AdminReportViewDTO.java
+++ b/src/main/java/com/grepp/funfun/app/domain/admin/dto/AdminReportViewDTO.java
@@ -1,0 +1,22 @@
+package com.grepp.funfun.app.domain.admin.dto;
+
+import com.grepp.funfun.app.domain.admin.vo.ReportSourceType;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class AdminReportViewDTO {
+    private Long id;
+
+    private String reportingUserEmail;
+    private String reportedUserEmail; // 문의 신고는 null 으로 지정
+
+    private String reason; // Report.reason && Contact.content
+    private ReportSourceType sourceType; // 신고 경로 button or contact
+
+    private boolean resolved;
+    private String adminComment; // Report.adminComment && Contact.answer
+    private LocalDateTime reportedAt;
+    private LocalDateTime resolvedAt;
+}

--- a/src/main/java/com/grepp/funfun/app/domain/admin/dto/payload/AdminReportProcessRequest.java
+++ b/src/main/java/com/grepp/funfun/app/domain/admin/dto/payload/AdminReportProcessRequest.java
@@ -1,0 +1,11 @@
+package com.grepp.funfun.app.domain.admin.dto.payload;
+
+import lombok.Data;
+
+@Data
+public class AdminReportProcessRequest {
+
+    private boolean takeAction;
+    private int suspendDays;
+    private String adminComment;
+}

--- a/src/main/java/com/grepp/funfun/app/domain/admin/service/AdminReportService.java
+++ b/src/main/java/com/grepp/funfun/app/domain/admin/service/AdminReportService.java
@@ -1,0 +1,120 @@
+package com.grepp.funfun.app.domain.admin.service;
+
+import com.grepp.funfun.app.domain.admin.dto.AdminReportViewDTO;
+import com.grepp.funfun.app.domain.admin.dto.payload.AdminReportProcessRequest;
+import com.grepp.funfun.app.domain.admin.vo.ReportSourceType;
+import com.grepp.funfun.app.domain.contact.entity.Contact;
+import com.grepp.funfun.app.domain.contact.repository.ContactRepository;
+import com.grepp.funfun.app.domain.contact.vo.ContactCategory;
+import com.grepp.funfun.app.domain.contact.vo.ContactStatus;
+import com.grepp.funfun.app.domain.report.entity.Report;
+import com.grepp.funfun.app.domain.report.repository.ReportRepository;
+import com.grepp.funfun.app.infra.error.exceptions.CommonException;
+import com.grepp.funfun.app.infra.response.ResponseCode;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminReportService {
+
+    private final ReportRepository reportRepository;
+    private final ContactRepository contactRepository;
+    private final AdminUserService adminUserService;
+
+    public List<AdminReportViewDTO> getAllReports(String status) {
+        List<AdminReportViewDTO> combined = new ArrayList<>();
+
+        List<Report> reports = reportRepository.findAll();
+        List<Contact> contacts = contactRepository.findAll().stream()
+                .filter(c -> c.getCategory() == ContactCategory.REPORT)
+                .toList();
+
+        if(status.equalsIgnoreCase("resolved")) {
+            reports = reports.stream().filter(Report::isResolved).toList();
+            contacts = contacts.stream().filter(c -> c.getStatus() == ContactStatus.COMPLETE).toList();
+        } else if (status.equalsIgnoreCase("unresolved")) {
+            reports = reports.stream().filter(r -> !r.isResolved()).toList();
+            contacts = contacts.stream().filter(c -> c.getStatus() == ContactStatus.PENDING).toList();
+        }
+
+        for(Report r : reports) {
+            AdminReportViewDTO dto = new AdminReportViewDTO();
+            dto.setId(r.getId());
+            dto.setReportingUserEmail(r.getReportingUser().getEmail());
+            dto.setReportedUserEmail(r.getReportedUser().getEmail());
+            dto.setReason(r.getReason());
+            dto.setSourceType(ReportSourceType.BUTTON_REPORT);
+            dto.setResolved(r.isResolved());
+            dto.setAdminComment(r.getAdminComment());
+            dto.setReportedAt(r.getCreatedAt());
+            dto.setResolvedAt(r.getResolvedAt());
+            combined.add(dto);
+        }
+
+        for (Contact c : contacts) {
+            AdminReportViewDTO dto = new AdminReportViewDTO();
+            dto.setId(c.getId());
+            dto.setReportingUserEmail(c.getUser().getEmail());
+            dto.setReportedUserEmail(null);
+            dto.setReason(c.getContent());
+            dto.setSourceType(ReportSourceType.CONTACT_REPORT);
+            dto.setResolved(c.getStatus() == ContactStatus.COMPLETE);
+            dto.setAdminComment(c.getAnswer());
+            dto.setReportedAt(c.getCreatedAt());
+            dto.setResolvedAt(c.getAnsweredAt());
+            combined.add(dto);
+        }
+
+        combined.sort(Comparator.comparing(AdminReportViewDTO::getReportedAt).reversed());
+
+        return combined;
+    }
+
+    @Transactional
+    public void processReport(Long id, AdminReportProcessRequest request) {
+        Optional<Report> optionalReport = reportRepository.findById(id);
+        if (optionalReport.isPresent()) {
+            Report report = optionalReport.get();
+
+            if(report.isResolved()) {
+                throw new CommonException(ResponseCode.BAD_REQUEST, "이미 처리 완료된 신고입니다.");
+            }
+
+            if(request.isTakeAction()) {
+                adminUserService.suspendUser(
+                        report.getReportedUser().getEmail(),
+                        request.getSuspendDays(),
+                        request.getAdminComment()
+                );
+            }
+
+            report.setResolved(true);
+            report.setAdminComment(request.getAdminComment());
+            report.setResolvedAt(LocalDateTime.now());
+            return;
+        }
+
+        Contact contact = contactRepository.findById(id)
+                .orElseThrow(() -> new CommonException(ResponseCode.NOT_FOUND, "신고(ID=" + id + ")를 찾을 수 없습니다."));
+
+                if (contact.getCategory() != ContactCategory.REPORT) {
+                    throw new CommonException(ResponseCode.BAD_REQUEST, "신고 유형의 문의가 아닙니다.");
+                }
+
+                if (contact.getStatus() == ContactStatus.COMPLETE) {
+                    throw new CommonException(ResponseCode.BAD_REQUEST, "이미 처리 완료된 신고입니다.");
+                }
+
+                contact.setAnswer(request.getAdminComment());
+                contact.setStatus(ContactStatus.COMPLETE);
+                contact.setAnsweredAt(LocalDateTime.now());
+    }
+}

--- a/src/main/java/com/grepp/funfun/app/domain/admin/vo/ReportSourceType.java
+++ b/src/main/java/com/grepp/funfun/app/domain/admin/vo/ReportSourceType.java
@@ -1,0 +1,6 @@
+package com.grepp.funfun.app.domain.admin.vo;
+
+public enum ReportSourceType {
+    BUTTON_REPORT,
+    CONTACT_REPORT,
+}

--- a/src/main/java/com/grepp/funfun/app/domain/report/entity/Report.java
+++ b/src/main/java/com/grepp/funfun/app/domain/report/entity/Report.java
@@ -18,6 +18,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
+
 
 @Entity
 @Getter
@@ -46,4 +48,9 @@ public class Report extends BaseEntity {
     @JoinColumn(name = "reported_user_id", nullable = false)
     private User reportedUser;
 
+    private boolean resolved = false;
+
+    private String adminComment;
+
+    private LocalDateTime resolvedAt;
 }

--- a/src/main/java/com/grepp/funfun/app/domain/user/entity/User.java
+++ b/src/main/java/com/grepp/funfun/app/domain/user/entity/User.java
@@ -78,4 +78,8 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user")
     private List<ContentPreference> contentPreferences = new ArrayList<>();
 
+    public boolean isAdmin() {
+        return this.role == Role.ROLE_ADMIN;
+    }
+
 }


### PR DESCRIPTION
## 📌 과제 설명 
관리자 신고 조회 및 응답 , 제재 기능을 구현했습니다.

## 👩‍💻 요구 사항과 구현 내용
✅ 신고 통합 조회
- Report와 Contact (REPORT 카테고리) 모두 조회
- status 파라미터를 통한 필터링 기능 추가 (all, resolved, unresolved)

✅ 신고 처리
- 버튼형 신고 (Report)
- 관리자 메모 작성
- 유저 제재 기능 (suspendDays, takeAction 활용)

- 문의형 신고 (Contact - REPORT 카테고리)
-QnA 답변 등록 (답변 완료 처리)

-ReportSourceType : 신고 유형 구분 (BUTTON_REPORT, CONTACT_REPORT)
