### PR TITLE
feat: Page 적용 및 인증 로직 수정

### DIFF
--- a/src/main/java/com/grepp/funfun/app/domain/auth/controller/AuthApiController.java
+++ b/src/main/java/com/grepp/funfun/app/domain/auth/controller/AuthApiController.java
@@ -34,7 +34,7 @@ public class AuthApiController {
         @RequestBody @Valid LoginRequest loginRequest,
         HttpServletResponse response
     ) {
-        TokenDto tokenDto = authService.signin(loginRequest);
+        TokenDto tokenDto = authService.login(loginRequest);
         TokenCookieFactory.setAllAuthCookies(response, tokenDto);
 
         // 취향 설정을 하지 않은 사용자

--- a/src/main/java/com/grepp/funfun/app/domain/auth/service/AuthService.java
+++ b/src/main/java/com/grepp/funfun/app/domain/auth/service/AuthService.java
@@ -35,7 +35,7 @@ public class AuthService {
     private final UserBlackListRepository userBlackListRepository;
     private final UserRepository userRepository;
 
-    public TokenDto signin(LoginRequest loginRequest) {
+    public TokenDto login(LoginRequest loginRequest) {
         UsernamePasswordAuthenticationToken authenticationToken =
             new UsernamePasswordAuthenticationToken(loginRequest.getEmail(),
                 loginRequest.getPassword());
@@ -78,11 +78,11 @@ public class AuthService {
         SecurityContextHolder.getContext().setAuthentication(authentication);
         String roles = String.join(",",
             authentication.getAuthorities().stream().map(GrantedAuthority::getAuthority).toList());
-        return processTokenSignin(authentication.getName(), user.getNickname(), roles, loginRequest.isRememberMe());
+        return processTokenLogin(authentication.getName(), user.getNickname(), roles, loginRequest.isRememberMe());
     }
 
     @Transactional
-    public TokenDto processTokenSignin(String email, String nickname, String roles, boolean rememberMe) {
+    public TokenDto processTokenLogin(String email, String nickname, String roles, boolean rememberMe) {
         // black list 에 있다면 해제
         userBlackListRepository.deleteById(email);
 
@@ -103,7 +103,9 @@ public class AuthService {
     }
 
     @Transactional
-    public TokenDto reissueAccessToken(Authentication authentication, String nickname, String roles) {
+    public TokenDto reissueAccessToken(String nickname, String roles) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
         Principal principal = (Principal) authentication.getPrincipal();
         String accessToken = principal.getAccessToken().orElseThrow(() -> new CommonException(ResponseCode.UNAUTHORIZED));
         String atId = jwtTokenProvider.getClaims(accessToken).getId();

--- a/src/main/java/com/grepp/funfun/app/domain/calendar/repository/CalendarRepositoryCustom.java
+++ b/src/main/java/com/grepp/funfun/app/domain/calendar/repository/CalendarRepositoryCustom.java
@@ -5,6 +5,8 @@ import com.grepp.funfun.app.domain.calendar.dto.payload.CalendarDailyResponse;
 import com.grepp.funfun.app.domain.calendar.dto.payload.CalendarMonthlyResponse;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -13,5 +15,5 @@ public interface CalendarRepositoryCustom {
     List<CalendarMonthlyResponse> findMonthlyGroupCalendars(String email, LocalDateTime start, LocalDateTime end);
     List<CalendarDailyResponse> findDailyContentCalendars(String email, LocalDateTime start, LocalDateTime end);
     List<CalendarDailyResponse> findDailyGroupCalendars(String email, LocalDateTime start, LocalDateTime end);
-    List<CalendarContentResponse> findContentByEmail(String email);
+    Page<CalendarContentResponse> findContentByEmail(String email, boolean pastIncluded, Pageable pageable);
 }

--- a/src/main/java/com/grepp/funfun/app/domain/calendar/service/CalendarService.java
+++ b/src/main/java/com/grepp/funfun/app/domain/calendar/service/CalendarService.java
@@ -22,6 +22,8 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -129,8 +131,8 @@ public class CalendarService {
     }
 
     @Transactional(readOnly = true)
-    public List<CalendarContentResponse> getContent(String email) {
-        return calendarRepository.findContentByEmail(email);
+    public Page<CalendarContentResponse> getContent(String email, boolean pastIncluded, Pageable pageable) {
+        return calendarRepository.findContentByEmail(email, pastIncluded, pageable);
     }
 
     @Transactional

--- a/src/main/java/com/grepp/funfun/app/domain/calendar/service/CalendarService.java
+++ b/src/main/java/com/grepp/funfun/app/domain/calendar/service/CalendarService.java
@@ -69,7 +69,7 @@ public class CalendarService {
             .orElseThrow(() -> new CommonException(ResponseCode.NOT_FOUND));
 
         if(calendar.getType() == ActivityType.GROUP) {
-            throw new CommonException(ResponseCode.BAD_REQUEST);
+            throw new CommonException(ResponseCode.BAD_REQUEST, "모임 일정은 직접 삭제할 수 없습니다.");
         }
 
         // bookmarkCount--;
@@ -87,7 +87,7 @@ public class CalendarService {
             .orElseThrow(() -> new CommonException(ResponseCode.NOT_FOUND));
 
         if (calendar.getType() == ActivityType.GROUP) {
-            throw new CommonException(ResponseCode.BAD_REQUEST);
+            throw new CommonException(ResponseCode.BAD_REQUEST, "모임 일정은 직접 수정할 수 없습니다.");
         }
 
         calendar.setSelectedDate(selectedDate);

--- a/src/main/java/com/grepp/funfun/app/domain/contact/controller/ContactApiController.java
+++ b/src/main/java/com/grepp/funfun/app/domain/contact/controller/ContactApiController.java
@@ -40,16 +40,25 @@ public class ContactApiController {
         사용자의 문의 목록을 조회합니다.
         
         • status: 상태 필터를 지정할 수 있습니다.
-            - all, pending, complete
+        
+            - all(모두), pending(답변 대기), complete(답변 완료)
         
         • page: 0 ~ N, 보고 싶은 페이지를 지정할 수 있습니다.
+        
             - 기본값: 0
         
         • size: 기본 페이지당 항목 수
+        
             - 기본값 : 10
         
         • sort: 정렬
-            - 기본값 : createdAt, DESC (최신순)
+        
+            - 정렬 가능한 필드:
+                        - `createdAt` (문의 작성한 시간)
+        
+            - 정렬 방식 예시:
+                        - `?sort=createdAt,desc` (기본값, 최신순)
+                        - `?sort=createdAt,asc` (오래된순)
         """)
     public ResponseEntity<ApiResponse<Page<ContactResponse>>> getAllContacts(
         Authentication authentication,

--- a/src/main/java/com/grepp/funfun/app/domain/social/controller/FollowApiController.java
+++ b/src/main/java/com/grepp/funfun/app/domain/social/controller/FollowApiController.java
@@ -49,12 +49,15 @@ public class FollowApiController {
     @GetMapping("/followers")
     @Operation(summary = "팔로워 조회", description = """
         팔로워 목록을 조회합니다.
+        
         기본 정렬은 닉네임 오름차순입니다.
         
         • page: 0 ~ N, 보고 싶은 페이지를 지정할 수 있습니다.
+        
             - 기본값: 0
         
         • size: 기본 페이지당 항목 수
+        
             - 기본값 : 10
         
         • sort: 정렬
@@ -80,12 +83,15 @@ public class FollowApiController {
     @GetMapping("/followings")
     @Operation(summary = "팔로잉 조회", description = """
         팔로잉 목록을 조회합니다.
+        
         기본 정렬은 닉네임 오름차순입니다.
         
         • page: 0 ~ N, 보고 싶은 페이지를 지정할 수 있습니다.
+        
             - 기본값: 0
         
         • size: 기본 페이지당 항목 수
+        
             - 기본값 : 10
         
         • sort: 정렬

--- a/src/main/java/com/grepp/funfun/app/domain/social/controller/FollowApiController.java
+++ b/src/main/java/com/grepp/funfun/app/domain/social/controller/FollowApiController.java
@@ -4,8 +4,14 @@ import com.grepp.funfun.app.domain.social.dto.payload.FollowsResponse;
 import com.grepp.funfun.app.domain.social.service.FollowService;
 import com.grepp.funfun.app.infra.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -49,10 +55,34 @@ public class FollowApiController {
     }
 
     @GetMapping("/followings")
-    @Operation(summary = "팔로잉 조회", description = "팔로잉 목록을 조회합니다.")
-    public ResponseEntity<ApiResponse<List<FollowsResponse>>> getFollowings(Authentication authentication) {
+    @Operation(summary = "팔로잉 조회", description = """
+        팔로잉 목록을 조회합니다.
+        기본 정렬은 닉네임 오름차순입니다.
+        
+        • page: 0 ~ N, 보고 싶은 페이지를 지정할 수 있습니다.
+            - 기본값: 0
+        
+        • size: 기본 페이지당 항목 수
+            - 기본값 : 10
+        
+        • sort: 정렬
+        
+            - 정렬 가능한 필드:
+                        - `nickname` (닉네임)
+                        - `createdAt` (팔로우한 시간)
+        
+            - 정렬 방식 예시:
+                        - `?sort=createdAt,desc` (최신순)
+                        - `?sort=createdAt,asc` (오래된순)
+                        - `?sort=nickname,asc` (기본값, 닉네임 오름차순)
+        """)
+    public ResponseEntity<ApiResponse<Page<FollowsResponse>>> getFollowings(
+        Authentication authentication,
+        @Parameter(hidden = true)
+        @ParameterObject
+        @PageableDefault(sort = "nickname", direction = Sort.Direction.ASC) Pageable pageable) {
         String email = authentication.getName();
-        return ResponseEntity.ok(ApiResponse.success(followService.getFollowings(email)));
+        return ResponseEntity.ok(ApiResponse.success(followService.getFollowings(email, pageable)));
     }
 
     @GetMapping("/count/followers")

--- a/src/main/java/com/grepp/funfun/app/domain/social/controller/FollowApiController.java
+++ b/src/main/java/com/grepp/funfun/app/domain/social/controller/FollowApiController.java
@@ -5,7 +5,6 @@ import com.grepp.funfun.app.domain.social.service.FollowService;
 import com.grepp.funfun.app.infra.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
@@ -48,10 +47,34 @@ public class FollowApiController {
     }
 
     @GetMapping("/followers")
-    @Operation(summary = "팔로워 조회", description = "팔로워 목록을 조회합니다.")
-    public ResponseEntity<ApiResponse<List<FollowsResponse>>> getFollowers(Authentication authentication) {
+    @Operation(summary = "팔로워 조회", description = """
+        팔로워 목록을 조회합니다.
+        기본 정렬은 닉네임 오름차순입니다.
+        
+        • page: 0 ~ N, 보고 싶은 페이지를 지정할 수 있습니다.
+            - 기본값: 0
+        
+        • size: 기본 페이지당 항목 수
+            - 기본값 : 10
+        
+        • sort: 정렬
+        
+            - 정렬 가능한 필드:
+                        - `nickname` (닉네임)
+                        - `createdAt` (팔로우한 시간)
+        
+            - 정렬 방식 예시:
+                        - `?sort=createdAt,desc` (최신순)
+                        - `?sort=createdAt,asc` (오래된순)
+                        - `?sort=nickname,asc` (기본값, 닉네임 오름차순)
+        """)
+    public ResponseEntity<ApiResponse<Page<FollowsResponse>>> getFollowers(
+        Authentication authentication,
+        @Parameter(hidden = true)
+        @ParameterObject
+        @PageableDefault(sort = "nickname", direction = Sort.Direction.ASC) Pageable pageable) {
         String email = authentication.getName();
-        return ResponseEntity.ok(ApiResponse.success(followService.getFollowers(email)));
+        return ResponseEntity.ok(ApiResponse.success(followService.getFollowers(email, pageable)));
     }
 
     @GetMapping("/followings")

--- a/src/main/java/com/grepp/funfun/app/domain/social/repository/FollowRepositoryCustom.java
+++ b/src/main/java/com/grepp/funfun/app/domain/social/repository/FollowRepositoryCustom.java
@@ -1,13 +1,12 @@
 package com.grepp.funfun.app.domain.social.repository;
 
 import com.grepp.funfun.app.domain.social.dto.payload.FollowsResponse;
-import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FollowRepositoryCustom {
-    List<FollowsResponse> findFollowersByFolloweeEmail(String followeeEmail);
+    Page<FollowsResponse> findFollowersByFolloweeEmail(String followeeEmail, Pageable pageable);
     Page<FollowsResponse> findFollowingsByFollowerEmail(String followerEmail, Pageable pageable);
 }

--- a/src/main/java/com/grepp/funfun/app/domain/social/repository/FollowRepositoryCustom.java
+++ b/src/main/java/com/grepp/funfun/app/domain/social/repository/FollowRepositoryCustom.java
@@ -2,10 +2,12 @@ package com.grepp.funfun.app.domain.social.repository;
 
 import com.grepp.funfun.app.domain.social.dto.payload.FollowsResponse;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FollowRepositoryCustom {
     List<FollowsResponse> findFollowersByFolloweeEmail(String followeeEmail);
-    List<FollowsResponse> findFollowingsByFollowerEmail(String followerEmail);
+    Page<FollowsResponse> findFollowingsByFollowerEmail(String followerEmail, Pageable pageable);
 }

--- a/src/main/java/com/grepp/funfun/app/domain/social/repository/FollowRepositoryCustomImpl.java
+++ b/src/main/java/com/grepp/funfun/app/domain/social/repository/FollowRepositoryCustomImpl.java
@@ -4,10 +4,17 @@ import com.grepp.funfun.app.domain.social.dto.payload.FollowsResponse;
 import com.grepp.funfun.app.domain.social.entity.QFollow;
 import com.grepp.funfun.app.domain.user.entity.QUser;
 import com.grepp.funfun.app.domain.user.entity.QUserInfo;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.support.PageableExecutionUtils;
 
 @RequiredArgsConstructor
 public class FollowRepositoryCustomImpl implements FollowRepositoryCustom {
@@ -34,8 +41,8 @@ public class FollowRepositoryCustomImpl implements FollowRepositoryCustom {
     }
 
     @Override
-    public List<FollowsResponse> findFollowingsByFollowerEmail(String followerEmail) {
-        return queryFactory
+    public Page<FollowsResponse> findFollowingsByFollowerEmail(String followerEmail, Pageable pageable) {
+        List<FollowsResponse> content = queryFactory
             .select(Projections.constructor(
                 FollowsResponse.class,
                 user.email,
@@ -46,6 +53,30 @@ public class FollowRepositoryCustomImpl implements FollowRepositoryCustom {
             .join(follow.followee, user)
             .join(user.info, userInfo)
             .where(follow.follower.email.eq(followerEmail))
+            .orderBy(getOrderSpecifiers(pageable.getSort()))
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
             .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+            .select(follow.count())
+            .from(follow)
+            .where(follow.follower.email.eq(followerEmail));
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    private OrderSpecifier<?>[] getOrderSpecifiers(Sort sort) {
+        return sort.stream()
+            .map(order -> {
+                String property = order.getProperty();
+                Order direction = order.isAscending() ? Order.ASC : Order.DESC;
+
+                return switch (property) {
+                    case "createdAt" -> new OrderSpecifier<>(direction, follow.createdAt);
+                    case "nickname" -> new OrderSpecifier<>(direction, user.nickname);
+                    default -> new OrderSpecifier<>(Order.ASC, user.nickname);
+                };
+            }).toArray(OrderSpecifier[]::new);
     }
 }

--- a/src/main/java/com/grepp/funfun/app/domain/social/service/FollowService.java
+++ b/src/main/java/com/grepp/funfun/app/domain/social/service/FollowService.java
@@ -10,6 +10,8 @@ import com.grepp.funfun.app.infra.error.exceptions.CommonException;
 import com.grepp.funfun.app.infra.response.ResponseCode;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -60,8 +62,8 @@ public class FollowService {
         return followRepository.findFollowersByFolloweeEmail(email);
     }
 
-    public List<FollowsResponse> getFollowings(String email) {
-        return followRepository.findFollowingsByFollowerEmail(email);
+    public Page<FollowsResponse> getFollowings(String email, Pageable pageable) {
+        return followRepository.findFollowingsByFollowerEmail(email, pageable);
     }
 
     public long countFollowers(String email) {

--- a/src/main/java/com/grepp/funfun/app/domain/social/service/FollowService.java
+++ b/src/main/java/com/grepp/funfun/app/domain/social/service/FollowService.java
@@ -33,7 +33,7 @@ public class FollowService {
     public void follow(String followerEmail, String followeeEmail) {
         if (followerEmail.equals(followeeEmail)) {
             // 자기 자신은 팔로우할 수 없습니다.
-            throw new CommonException(ResponseCode.BAD_REQUEST);
+            throw new CommonException(ResponseCode.BAD_REQUEST, "자기 자신은 팔로우할 수 없습니다.");
         }
 
         boolean exists = followRepository.existsByFollowerEmailAndFolloweeEmail(followerEmail, followeeEmail);
@@ -44,7 +44,7 @@ public class FollowService {
             followRepository.save(follow);
         } else {
             // 이미 팔로우한 사용자입니다.
-            throw new CommonException(ResponseCode.BAD_REQUEST);
+            throw new CommonException(ResponseCode.BAD_REQUEST, "이미 팔로우한 사용자입니다.");
         }
     }
 
@@ -53,7 +53,7 @@ public class FollowService {
         boolean exists = followRepository.existsByFollowerEmailAndFolloweeEmail(followerEmail, followeeEmail);
         if (!exists) {
             // 팔로우 관계가 아닙니다.
-         throw new CommonException(ResponseCode.BAD_REQUEST);
+         throw new CommonException(ResponseCode.BAD_REQUEST, "팔로우 관계가 아닙니다.");
         }
         followRepository.deleteByFollowerEmailAndFolloweeEmail(followerEmail, followeeEmail);
     }

--- a/src/main/java/com/grepp/funfun/app/domain/social/service/FollowService.java
+++ b/src/main/java/com/grepp/funfun/app/domain/social/service/FollowService.java
@@ -58,8 +58,8 @@ public class FollowService {
         followRepository.deleteByFollowerEmailAndFolloweeEmail(followerEmail, followeeEmail);
     }
 
-    public List<FollowsResponse> getFollowers(String email) {
-        return followRepository.findFollowersByFolloweeEmail(email);
+    public Page<FollowsResponse> getFollowers(String email, Pageable pageable) {
+        return followRepository.findFollowersByFolloweeEmail(email, pageable);
     }
 
     public Page<FollowsResponse> getFollowings(String email, Pageable pageable) {

--- a/src/main/java/com/grepp/funfun/app/domain/user/controller/UserApiController.java
+++ b/src/main/java/com/grepp/funfun/app/domain/user/controller/UserApiController.java
@@ -26,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -98,6 +99,7 @@ public class UserApiController {
         String email = authentication.getName();
         userService.unActive(email, accessTokenId);
 
+        SecurityContextHolder.clearContext();
         TokenCookieFactory.setAllExpiredCookies(response);
 
         return ResponseEntity.ok(ApiResponse.success("회원 탈퇴되었습니다."));

--- a/src/main/java/com/grepp/funfun/app/domain/user/controller/UserApiController.java
+++ b/src/main/java/com/grepp/funfun/app/domain/user/controller/UserApiController.java
@@ -57,7 +57,8 @@ public class UserApiController {
     @PatchMapping("/oauth2/signup")
     @Operation(summary = "OAuth2 회원가입", description = "소셜 로그인 대상의 추가 정보를 입력 받습니다.<br>액세스 토큰을 재발급합니다.")
     public ResponseEntity<ApiResponse<TokenResponse>> updateOAuth2User(@RequestBody @Valid OAuth2SignupRequest request, Authentication authentication, HttpServletResponse response) {
-        TokenDto tokenDto = userService.updateOAuth2User(authentication, request);
+        String email = authentication.getName();
+        TokenDto tokenDto = userService.updateOAuth2User(email, request);
         TokenCookieFactory.setAllAuthCookies(response, tokenDto);
 
         return ResponseEntity.ok(ApiResponse.success(TokenResponse.builder().
@@ -155,7 +156,8 @@ public class UserApiController {
     @Operation(summary = "닉네임 변경", description = "닉네임 변경을 합니다.<br>액세스 토큰을 재발급합니다.")
     public ResponseEntity<ApiResponse<TokenResponse>> changeNickname(@RequestBody @Valid
     NicknameRequest request, Authentication authentication, HttpServletResponse response) {
-        TokenDto tokenDto = userService.changeNickname(authentication, request.getNickname());
+        String email = authentication.getName();
+        TokenDto tokenDto = userService.changeNickname(email, request.getNickname());
         TokenCookieFactory.setAllAuthCookies(response, tokenDto);
 
         return ResponseEntity.ok(ApiResponse.success(TokenResponse.builder().

--- a/src/main/java/com/grepp/funfun/app/domain/user/service/UserService.java
+++ b/src/main/java/com/grepp/funfun/app/domain/user/service/UserService.java
@@ -222,7 +222,7 @@ public class UserService {
         User user = userRepository.findById(email).orElseThrow(() -> new CommonException(ResponseCode.NOT_FOUND));
 
         if (!redisTemplate.hasKey(verifiedKey)) {
-            throw new CommonException(ResponseCode.BAD_REQUEST);
+            throw new CommonException(ResponseCode.EXPIRED_AUTH_CODE_VERIFY);
         }
 
         // 비밀번호 암호화

--- a/src/main/java/com/grepp/funfun/app/infra/auth/jwt/filter/LogoutFilter.java
+++ b/src/main/java/com/grepp/funfun/app/infra/auth/jwt/filter/LogoutFilter.java
@@ -12,6 +12,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -39,7 +40,9 @@ public class LogoutFilter extends OncePerRequestFilter {
                 refreshTokenService.deleteByAccessTokenId(claims.getId());
             }
 
+            SecurityContextHolder.clearContext();
             TokenCookieFactory.setAllExpiredCookies(response);
+
             response.sendRedirect(front + "/");
             return;
         }

--- a/src/main/java/com/grepp/funfun/app/infra/auth/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/grepp/funfun/app/infra/auth/oauth2/OAuth2SuccessHandler.java
@@ -64,7 +64,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
             userRepository.save(newUser);
             log.info("OAuth2 사용자 기본 정보 저장: {}", email);
 
-            TokenDto tokenDto = authService.processTokenSignin(email, "", newUser.getRole().name(), false);
+            TokenDto tokenDto = authService.processTokenLogin(email, "", newUser.getRole().name(), false);
             TokenCookieFactory.setAllAuthCookies(response, tokenDto);
 
             // NOTE : 프론트 경로로 변경 필요
@@ -74,7 +74,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
             User user = userRepository.findById(email).orElse(null);
 
             if (user != null) {
-                TokenDto tokenDto = authService.processTokenSignin(email, user.getNickname() ,user.getRole().name(), false);
+                TokenDto tokenDto = authService.processTokenLogin(email, user.getNickname() ,user.getRole().name(), false);
 
                 TokenCookieFactory.setAllAuthCookies(response, tokenDto);
 

--- a/src/main/java/com/grepp/funfun/app/infra/error/RestApiExceptionAdvice.java
+++ b/src/main/java/com/grepp/funfun/app/infra/error/RestApiExceptionAdvice.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.ui.Model;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -54,6 +55,14 @@ public class RestApiExceptionAdvice {
                    .body(ApiResponse.error(ResponseCode.UNAUTHORIZED));
     }
     
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<String>> httpMessageNotReadableExceptionHandler(HttpMessageNotReadableException ex) {
+        log.error(ex.getMessage(), ex);
+        return ResponseEntity
+                   .badRequest()
+                   .body(ApiResponse.error(ResponseCode.BAD_REQUEST, ex.getMessage()));
+    }
+
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ApiResponse<String>> runtimeExceptionHandler(RuntimeException ex) {
         log.error(ex.getMessage(), ex);

--- a/src/main/java/com/grepp/funfun/app/infra/response/ResponseCode.java
+++ b/src/main/java/com/grepp/funfun/app/infra/response/ResponseCode.java
@@ -24,6 +24,7 @@ public enum ResponseCode {
     USER_GUEST("4024", HttpStatus.OK, "추가 회원가입이 필요한 OAuth2 사용자입니다."),
     USER_PREFERENCE_NOT_SET("4025", HttpStatus.OK, "사용자의 선호 취향이 아직 설정되지 않았습니다."),
     OAUTH2_AUTHENTICATION_FAILED("4026", HttpStatus.UNAUTHORIZED, "OAuth2 로그인에 실패했습니다."),
+    EXPIRED_AUTH_CODE_VERIFY("4027", HttpStatus.BAD_REQUEST, "인증 코드 검증한 유효 기간(10분)이 지나거나 인증 코드 검증을 하지 않았습니다."),
     INTERNAL_SERVER_ERROR("5000", HttpStatus.INTERNAL_SERVER_ERROR, "서버에러 입니다."),
     SECURITY_INCIDENT("6000", HttpStatus.OK, "비정상적인 로그인 시도가 감지되었습니다.");
     

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -2073,6 +2073,8 @@ VALUES
     ('허위 정보를 포함하고 있어요', 'POST', 6, 't3@aaa.aaa', 't2@aaa.aaa', true, NOW(), NOW()),
     ('불쾌한 표현이 있어요', 'POST', 10, 't5@aaa.aaa', 't3@aaa.aaa', true, NOW(), NOW());
 
+ALTER TABLE contact ALTER COLUMN activated SET DEFAULT true;
+
 -- Contact 테이블 데이터 삽입
 INSERT INTO contact (title, content, category, status, answer, answered_at, user_id, created_at, modified_at)
 VALUES

--- a/src/test/java/com/grepp/funfun/app/domain/integrate/UserParticipantIntegrateTest.java
+++ b/src/test/java/com/grepp/funfun/app/domain/integrate/UserParticipantIntegrateTest.java
@@ -84,7 +84,7 @@ public class UserParticipantIntegrateTest {
         memberLoginRequest.setPassword(rawPassword);
 
         //로그인 실행
-        authService.signin(memberLoginRequest);
+        authService.login(memberLoginRequest);
         System.out.println("로그인 완료");
 
         //모임 참여 신청


### PR DESCRIPTION
## 📌 과제 설명 
Page 적용 및 인증 로직 수정했습니다.
## 👩‍💻 요구 사항과 구현 내용
* Page 적용
  * 팔로잉, 팔로워 목록
  * 일정 등록한 컨텐츠 목록
  * 문의 목록 - 정렬 수정
* 인증 로직 수정
  * 정지 당한 사용자 액세스 토큰 무효화
  * 인증 로직 리팩토링
    * signin -> login 명칭 통일
* 예외 처리
  *  HttpMessageNotReadableException.class
     * JSON -> Java 객체 변환 간 발생하는 예외 처리
  * BAD_REQUEST에 대한 메시지 추가  