### PR TITLE
feat: 부적절한 닉네임 무작위 변경 및 상태 갱신 처리 기능 추가

### DIFF
--- a/src/main/java/com/grepp/funfun/app/domain/admin/controller/AdminUserApiController.java
+++ b/src/main/java/com/grepp/funfun/app/domain/admin/controller/AdminUserApiController.java
@@ -71,4 +71,18 @@ public class AdminUserApiController {
         UserDTO user = adminUserService.getUserByNickname(nickname);
         return ResponseEntity.ok(ApiResponse.success(user));
     }
+
+    // 부적절한 닉네임 임의 숫자값 변경
+    @PostMapping("/{email}/randomize-nickname")
+    public ResponseEntity<ApiResponse<String>> randomizeNickname(
+            @PathVariable String email,
+            Authentication authentication) {
+
+        UserDTO admin = adminUserService.getAuthenticatedUser(authentication);
+        checkAdminRole(admin);
+
+        String newNickname = adminUserService.randomizeNickname(email);
+        return ResponseEntity.ok(ApiResponse.success(newNickname));
+    }
+
 }

--- a/src/main/java/com/grepp/funfun/app/domain/auth/service/AuthService.java
+++ b/src/main/java/com/grepp/funfun/app/domain/auth/service/AuthService.java
@@ -70,6 +70,10 @@ public class AuthService {
             }
         }
 
+        if(user.getStatus() == UserStatus.NONACTIVE) {
+            user.setStatus(UserStatus.ACTIVE);
+        }
+
         // 비활성화한 사용자 (Soft Delete)
         if (!user.getActivated()) {
             throw new CommonException(ResponseCode.USER_INACTIVE);

--- a/src/main/java/com/grepp/funfun/app/domain/user/dto/UserDTO.java
+++ b/src/main/java/com/grepp/funfun/app/domain/user/dto/UserDTO.java
@@ -2,17 +2,20 @@ package com.grepp.funfun.app.domain.user.dto;
 
 import com.grepp.funfun.app.domain.auth.vo.Role;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.grepp.funfun.app.domain.user.entity.User;
 import com.grepp.funfun.app.domain.user.vo.Gender;
 import com.grepp.funfun.app.domain.user.vo.UserStatus;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 
 @Getter
 @Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class UserDTO {
 
     @Size(max = 255)
@@ -62,4 +65,13 @@ public class UserDTO {
     @Size(max = 255)
     private String info;
 
+public static UserDTO from(User user) {
+    return UserDTO.builder()
+            .email(user.getEmail())
+            .nickname(user.getNickname())
+            .role(user.getRole())
+            .status(user.getStatus())
+            .isVerified(user.getIsVerified())
+            .build();
+    }
 }

--- a/src/main/java/com/grepp/funfun/app/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/grepp/funfun/app/domain/user/repository/UserRepository.java
@@ -22,4 +22,6 @@ public interface UserRepository extends JpaRepository<User, String>, UserReposit
     List<User> findAllByStatus(UserStatus status);
 
     Optional<User> findByNickname(String nickname);
+
+    Optional<User> findOptionalByEmail(String email);
 }

--- a/src/main/java/com/grepp/funfun/app/domain/user/vo/UserStatus.java
+++ b/src/main/java/com/grepp/funfun/app/domain/user/vo/UserStatus.java
@@ -4,6 +4,7 @@ package com.grepp.funfun.app.domain.user.vo;
 public enum UserStatus {
 
     ACTIVE("활성"),
+    NONACTIVE("비활성"),
     SUSPENDED("일시 정지"),
     BANNED("영구 정지");
 


### PR DESCRIPTION
## 📌 과제 설명
- 관리자 페이지에서 부적절한 닉네임을 무작위로 변경하고 상태를 nonactive 로 변경하며 
 해당 유저가 재로그인시 active 로 돌아오는 기능을 추가했습니다.
- 기존 스케줄러를 통한 상태 (suspended -> active) 갱신과 더불어 active 가 아닌 유저가 로그인했을 때 조건을 만족하는 경우 active로 갱신되는 기능을 추가했습니다.

## 👩‍💻 요구 사항과 구현 내용
- 관리자 페이지에서 부적절한 닉네임을 8자리 임의숫자값으로 변경할 수 있습니다.
- 해당 유저가 재로그인시 nonactive -> active로 변경됩니다.
- 유저가 로그인 할 때 status 가 suspended && dueDate <= 오늘  이거나 status 가 nonactive 이면 자동으로 active로 변경됩니다.

## ✅ 피드백 반영사항
- 닉네임 무작위 변경 유저의 상태를 suspended, duedate = 오늘날짜로 설정하는 로직에서 
- 신규 status인 nonactive 를 추가하여 해당 유저가 재로그인시 active로 변경되도록 수정했습니다. 
