### PR TITLE
feat: 응답 형식 수정

### DIFF
--- a/src/main/java/com/grepp/funfun/app/domain/calendar/dto/payload/CalendarMonthlyResponse.java
+++ b/src/main/java/com/grepp/funfun/app/domain/calendar/dto/payload/CalendarMonthlyResponse.java
@@ -13,4 +13,5 @@ public class CalendarMonthlyResponse {
     private Long activityId;
     private String title;
     private LocalDateTime selectedDate;
+    private String address;
 }

--- a/src/main/java/com/grepp/funfun/app/domain/calendar/repository/CalendarRepositoryCustomImpl.java
+++ b/src/main/java/com/grepp/funfun/app/domain/calendar/repository/CalendarRepositoryCustomImpl.java
@@ -40,7 +40,8 @@ public class CalendarRepositoryCustomImpl implements CalendarRepositoryCustom{
                 calendar.type,
                 content.id,
                 content.contentTitle,
-                calendar.selectedDate
+                calendar.selectedDate,
+                content.address
             ))
             .from(calendar)
             .join(calendar.content, content)
@@ -60,7 +61,8 @@ public class CalendarRepositoryCustomImpl implements CalendarRepositoryCustom{
                 calendar.type,
                 group.id,
                 group.title,
-                group.groupDate
+                group.groupDate,
+                group.address
             ))
             .from(calendar)
             .join(calendar.group, group)

--- a/src/main/java/com/grepp/funfun/app/domain/social/dto/payload/FollowsResponse.java
+++ b/src/main/java/com/grepp/funfun/app/domain/social/dto/payload/FollowsResponse.java
@@ -8,7 +8,8 @@ import lombok.Data;
 @AllArgsConstructor
 @Builder
 public class FollowsResponse {
-    String email;
-    String nickname;
-    String imageUrl;
+    private String email;
+    private String nickname;
+    private String imageUrl;
+    private boolean isMutual;
 }


### PR DESCRIPTION
## 📌 과제 설명
팔로워/팔로잉 목록에 맞팔로우 여부도 함께 반환합니다.
캘린더 월별 일정 조회에 주소값 추가했습니다.
## 👩‍💻 요구 사항과 구현 내용
```
public class FollowsResponse {
    private String email;
    private String nickname;
    private String imageUrl;
    private boolean isMutual; // 맞팔로우 여부
}
```
```
public class CalendarMonthlyResponse {
    private Long calendarId;
    private ActivityType type;
    private Long activityId;
    private String title;
    private LocalDateTime selectedDate;
    private String address; // 주소값 추가
}
```

