### PR TITLE
fix: content 정렬 수정 및 리팩토링

### DIFF
--- a/src/main/java/com/grepp/funfun/app/domain/content/repository/ContentRepositoryCustomImpl.java
+++ b/src/main/java/com/grepp/funfun/app/domain/content/repository/ContentRepositoryCustomImpl.java
@@ -66,7 +66,6 @@ public class ContentRepositoryCustomImpl extends QuerydslRepositorySupport imple
                 .and(keywordEq(keyword));
 
         if (!includeExpired) {
-//            where.and(content.endDate.goe(LocalDate.now()));
             where.and(content.endDate.isNull().or(content.endDate.goe(LocalDate.now())));
         }
 

--- a/src/main/java/com/grepp/funfun/app/domain/content/service/ContentService.java
+++ b/src/main/java/com/grepp/funfun/app/domain/content/service/ContentService.java
@@ -213,6 +213,7 @@ public class ContentService {
     private ContentDTO toDTO(Content content) {
         return ContentDTO.builder()
                 .id(content.getId())
+                .externalId(content.getExternalId())
                 .contentTitle(content.getContentTitle())
                 .age(content.getAge())
                 .startDate(content.getStartDate())

--- a/src/main/java/com/grepp/funfun/app/domain/content/service/ContentService.java
+++ b/src/main/java/com/grepp/funfun/app/domain/content/service/ContentService.java
@@ -17,7 +17,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -145,7 +147,14 @@ public class ContentService {
 
         if (userLat == null || userLng == null) {
             log.warn("사용자 위치 정보를 확인할 수 없어 '마감 임박순'으로 정렬 방식을 변경합니다.");
-            return findByFiltersOrderByEndDate(request, pageable);
+
+            Pageable endDateSortedPageable = PageRequest.of(
+                    pageable.getPageNumber(),
+                    pageable.getPageSize(),
+                    Sort.by(Sort.Direction.ASC, "endDate")
+            );
+
+            return findByFiltersOrderByEndDate(request, endDateSortedPageable);
         }
 
         return contentRepository.findFilteredContentsByDistance(

--- a/src/main/java/com/grepp/funfun/app/domain/content/service/ContentService.java
+++ b/src/main/java/com/grepp/funfun/app/domain/content/service/ContentService.java
@@ -1,43 +1,42 @@
 package com.grepp.funfun.app.domain.content.service;
 
+import com.grepp.funfun.app.domain.calendar.repository.CalendarRepository;
+import com.grepp.funfun.app.domain.content.dto.ContentDTO;
+import com.grepp.funfun.app.domain.content.dto.ContentImageDTO;
 import com.grepp.funfun.app.domain.content.dto.ContentUrlDTO;
 import com.grepp.funfun.app.domain.content.dto.ContentWithReasonDTO;
 import com.grepp.funfun.app.domain.content.dto.payload.ContentFilterRequest;
-import com.grepp.funfun.app.domain.calendar.repository.CalendarRepository;
-import com.grepp.funfun.app.domain.content.vo.ContentClassification;
-import com.grepp.funfun.app.domain.content.dto.ContentDTO;
-import com.grepp.funfun.app.domain.content.dto.ContentImageDTO;
 import com.grepp.funfun.app.domain.content.entity.Content;
 import com.grepp.funfun.app.domain.content.repository.ContentRepository;
+import com.grepp.funfun.app.domain.content.vo.ContentClassification;
 import com.grepp.funfun.app.domain.user.dto.UserDTO;
 import com.grepp.funfun.app.domain.user.service.UserService;
 import com.grepp.funfun.app.infra.error.exceptions.CommonException;
 import com.grepp.funfun.app.infra.response.ResponseCode;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.*;
+import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
 
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
+@Transactional(readOnly = true)
 public class ContentService {
 
     private final ContentRepository contentRepository;
-    private final CalendarRepository calendarRepository;
     private final UserService userService;
+    private final ModelMapper modelMapper;
 
     // 컨텐츠 상세 조회
-    @Transactional
     public ContentDTO getContents(final Long id) {
         Content content = contentRepository.findByIdWithCategory(id)
                 .orElseThrow(() -> new CommonException(ResponseCode.NOT_FOUND));
@@ -45,7 +44,6 @@ public class ContentService {
     }
 
     // 컨텐츠 필터링(컨텐츠 조회)
-    @Transactional(readOnly = true)
     public Page<ContentDTO> findByFiltersWithSort(ContentFilterRequest request, Pageable pageable) {
         try {
             Page<Content> contents;
@@ -164,7 +162,6 @@ public class ContentService {
     }
 
     // 거리순 컨텐츠 노출
-    @Transactional(readOnly = true)
     public List<ContentDTO> findNearbyContents(Long id, double radiusInKm, int limit, boolean includeExpired) {
         Content content = contentRepository.findById(id)
                 .orElseThrow(() -> new CommonException(ResponseCode.NOT_FOUND));
@@ -211,44 +208,9 @@ public class ContentService {
     }
 
     private ContentDTO toDTO(Content content) {
-        return ContentDTO.builder()
-                .id(content.getId())
-                .externalId(content.getExternalId())
-                .contentTitle(content.getContentTitle())
-                .age(content.getAge())
-                .startDate(content.getStartDate())
-                .endDate(content.getEndDate())
-                .fee(content.getFee())
-                .address(content.getAddress())
-                .area(content.getArea())
-                .guname(content.getGuname())
-                .time(content.getTime())
-                .runTime(content.getRunTime())
-                .startTime(content.getStartTime())
-                .poster(content.getPoster())
-                .description(content.getDescription())
-                .bookmarkCount(Optional.ofNullable(content.getBookmarkCount()).orElse(0))
-                .eventType(content.getEventType())
-                .latitude(content.getLatitude())
-                .longitude(content.getLongitude())
-                .category(content.getCategory() != null ? content.getCategory().getCategory().name() : null)
-                .images(content.getImages().stream()
-                        .map(img -> ContentImageDTO.builder()
-                                .id(img.getId())
-                                .imageUrl(img.getImageUrl())
-                                .build())
-                        .toList())
-                .urls(content.getUrls().stream()
-                        .map(url -> ContentUrlDTO.builder()
-                                .id(url.getId())
-                                .siteName(url.getSiteName())
-                                .url(url.getUrl())
-                                .build())
-                        .toList())
-                .build();
+        return modelMapper.map(content, ContentDTO.class);
     }
 
-    @Transactional(readOnly = true)
     public List<ContentWithReasonDTO> findByIds(List<Long> recommendIds) {
         List<Content> contents = contentRepository.findContentsByIdsWithAllRelations(recommendIds);
 

--- a/src/main/java/com/grepp/funfun/app/domain/content/service/KakaoGeoService.java
+++ b/src/main/java/com/grepp/funfun/app/domain/content/service/KakaoGeoService.java
@@ -71,14 +71,12 @@ public class KakaoGeoService {
             }
             String fullAddress = addressOpt.get();
 
-            // 🔹 주소 시/도 불일치 시 삭제
             if (area != null && !fullAddress.startsWith(area)) {
                 log.warn("시/도 불일치: area={}, fullAddress={} → 삭제: {}", area, fullAddress, content.getId());
                 contentRepository.delete(content);
                 continue;
             }
 
-            // 구 이름 추출
             if (content.getGuname() == null) {
                 String guname = extractGunameFromAddress(fullAddress);
                 if (guname != null) {
@@ -86,7 +84,6 @@ public class KakaoGeoService {
                 }
             }
 
-            // 최종 주소 저장
             String finalAddress = fullAddress + " " + cleanedPlaceName;
             content.setAddress(finalAddress.trim());
 

--- a/src/main/java/com/grepp/funfun/app/infra/config/ModelMapperConfig.java
+++ b/src/main/java/com/grepp/funfun/app/infra/config/ModelMapperConfig.java
@@ -1,5 +1,8 @@
 package com.grepp.funfun.app.infra.config;
 
+import com.grepp.funfun.app.domain.content.dto.ContentDTO;
+import com.grepp.funfun.app.domain.content.entity.Content;
+import org.modelmapper.Converter;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.convention.MatchingStrategies;
 import org.springframework.context.annotation.Bean;
@@ -14,7 +17,23 @@ public class ModelMapperConfig {
         modelMapper.getConfiguration().setSkipNullEnabled(true);
         modelMapper.getConfiguration().setPreferNestedProperties(false);
         modelMapper.getConfiguration().setMatchingStrategy(MatchingStrategies.LOOSE);
+
+        Converter<Content, String> categoryConverter = ctx -> {
+            if (ctx.getSource() == null ||
+                    ctx.getSource().getCategory() == null ||
+                    ctx.getSource().getCategory().getCategory() == null) {
+                return null;
+            }
+            return ctx.getSource().getCategory().getCategory().name();
+        };
+        modelMapper.typeMap(Content.class, ContentDTO.class)
+                .addMappings(mapper ->
+                        mapper.using(categoryConverter)
+                                .map(src -> src, ContentDTO::setCategory)
+                );
+
         return modelMapper;
+
     }
     
 }


### PR DESCRIPTION
## 📌 과제 설명

## 👩‍💻 요구 사항과 구현 내용

- 리팩토링
    - **ModelMapper 적용**
        - ContentService: 커스텀 TypeMap을 활용해 ModelMapper 적용
        - DataPipeline: ModelMapper 미사용
            
            → XML 파싱 후 복잡한 매핑 로직이 많아 오히려 가독성이 떨어질 수 있어 직접 매핑 유지
            
- 비회원 컨텐츠 가까운순 정렬 → 마감 임박 순 정렬로 변경 수정
