### PR TITLE
refactor: admin group 목록을 불러오지 못하던 문제 해결

### DIFF
--- a/src/main/java/com/grepp/funfun/app/domain/admin/dto/payload/AdminGroupResponse.java
+++ b/src/main/java/com/grepp/funfun/app/domain/admin/dto/payload/AdminGroupResponse.java
@@ -12,7 +12,6 @@ public class AdminGroupResponse {
     private Long id;
     private String title;
     private String leaderEmail;
-    private String leaderNickname;
     private GroupStatus status;
     private int participantCount;
     private LocalDateTime groupDate;

--- a/src/main/java/com/grepp/funfun/app/domain/admin/mapper/AdminGroupMapper.java
+++ b/src/main/java/com/grepp/funfun/app/domain/admin/mapper/AdminGroupMapper.java
@@ -8,16 +8,14 @@ import org.springframework.stereotype.Component;
 public class AdminGroupMapper {
 
     public AdminGroupResponse toDto(Group group) {
-        String leaderEmail = group.getLeader() != null ? group.getLeader().getEmail() : "알 수 없음";
-        String leaderNickname = group.getLeader() != null ? group.getLeader().getNickname() : "알 수 없음";
+      String leaderEmail = group.getLeader() != null ? group.getLeader().getEmail() : "알 수 없음";
 
         return AdminGroupResponse.builder()
                 .id(group.getId())
                 .title(group.getTitle())
                 .leaderEmail(leaderEmail)
-                .leaderNickname(leaderNickname)
                 .status(group.getStatus())
-                .participantCount(group.getParticipants().size())
+                .participantCount(group.getNowPeople())
                 .groupDate(group.getGroupDate())
                 .deletedReason(extractReason(group.getExplain()))
                 .createdAt(group.getCreatedAt())

--- a/src/main/java/com/grepp/funfun/app/domain/admin/repository/AdminGroupRepositoryImpl.java
+++ b/src/main/java/com/grepp/funfun/app/domain/admin/repository/AdminGroupRepositoryImpl.java
@@ -17,11 +17,10 @@ import java.util.List;
 public class AdminGroupRepositoryImpl implements AdminGroupRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
+    private final  QGroup group = QGroup.group;
 
     @Override
     public Page<Group> findByStatus(GroupStatus status, Pageable pageable) {
-        QGroup group = QGroup.group;
-
         // enum 이라서
         BooleanExpression statusCondition = (status != null) ? group.status.eq(status) : null;
 

--- a/src/main/java/com/grepp/funfun/app/domain/admin/service/AdminGroupService.java
+++ b/src/main/java/com/grepp/funfun/app/domain/admin/service/AdminGroupService.java
@@ -1,5 +1,6 @@
 package com.grepp.funfun.app.domain.admin.service;
 
+import com.grepp.funfun.app.domain.admin.dto.payload.AdminGroupResponse;
 import com.grepp.funfun.app.domain.admin.repository.AdminGroupRepository;
 import com.grepp.funfun.app.domain.group.entity.Group;
 import com.grepp.funfun.app.domain.group.vo.GroupStatus;

--- a/src/main/java/com/grepp/funfun/app/domain/contact/entity/Contact.java
+++ b/src/main/java/com/grepp/funfun/app/domain/contact/entity/Contact.java
@@ -4,17 +4,8 @@ import com.grepp.funfun.app.domain.contact.vo.ContactCategory;
 import com.grepp.funfun.app.domain.contact.vo.ContactStatus;
 import com.grepp.funfun.app.domain.user.entity.User;
 import com.grepp.funfun.app.infra.entity.BaseEntity;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
+
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -49,6 +40,7 @@ public class Contact extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ContactStatus status;
 
+    @Column(columnDefinition = "TEXT")
     private String answer;
 
     private LocalDateTime answeredAt;

--- a/src/main/java/com/grepp/funfun/app/domain/faq/controller/FaqApiController.java
+++ b/src/main/java/com/grepp/funfun/app/domain/faq/controller/FaqApiController.java
@@ -5,6 +5,7 @@ import com.grepp.funfun.app.domain.faq.dto.payload.FaqUpdateRequest;
 import com.grepp.funfun.app.domain.faq.dto.FaqDTO;
 import com.grepp.funfun.app.domain.faq.service.FaqService;
 import com.grepp.funfun.app.infra.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -22,24 +23,28 @@ public class FaqApiController {
     private final FaqService faqService;
 
     @GetMapping
+    @Operation(summary = "전체 faq 조회", description = "모든 faq 목록을 조회합니다.")
     public ResponseEntity<ApiResponse<List<FaqDTO>>> getAllFaqs(){
         return ResponseEntity.ok(ApiResponse.success(faqService.findAll()));
     }
 
     // FAQ 상세조회
     @GetMapping("/{id}")
+    @Operation(summary = "faq 상세 조회", description = "특정 faq 를 상세조회합니다.")
     public ResponseEntity<ApiResponse<FaqDTO>> getFaqById(@PathVariable final Long id){
         return ResponseEntity.ok(ApiResponse.success(faqService.get(id)));
     }
 
     // FAQ 생성
     @PostMapping
+    @Operation(summary = "faq 신규 생성", description = "신규 faq 를 생성합니다.")
     public ResponseEntity<ApiResponse<Long>> createFaq(@RequestBody @Valid final FaqCreateRequest request){
         Long id = faqService.createFromRequest(request);
     return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(id));
     }
 
     @PutMapping("/{id}")
+    @Operation(summary = "faq 수정", description = "가존 생성된 faq 를 수정합니다.")
     public ResponseEntity<ApiResponse<Long>> updateFaq(@PathVariable Long id, @RequestBody @Valid final FaqUpdateRequest request){
         faqService.updateFromRequest(id, request);
         return ResponseEntity.ok(ApiResponse.success(id));
@@ -47,6 +52,7 @@ public class FaqApiController {
 
     // FAQ 삭제
     @DeleteMapping("/{id}")
+    @Operation(summary = "faq 삭제", description = "faq 를 삭제합니다. 되돌릴 수 없습니다.")
     public ResponseEntity<ApiResponse<Void>> deleteFaq(@PathVariable final Long id){
         faqService.delete(id);
         return ResponseEntity.ok(ApiResponse.noContent());

--- a/src/main/java/com/grepp/funfun/app/domain/faq/entity/Faq.java
+++ b/src/main/java/com/grepp/funfun/app/domain/faq/entity/Faq.java
@@ -19,4 +19,8 @@ public class Faq extends BaseEntity {
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
+
+    public void setActivated(Boolean activated) {
+        this.activated = activated;
+    }
 }

--- a/src/main/java/com/grepp/funfun/app/domain/faq/entity/Faq.java
+++ b/src/main/java/com/grepp/funfun/app/domain/faq/entity/Faq.java
@@ -20,7 +20,4 @@ public class Faq extends BaseEntity {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
-    public void setActivated(Boolean activated) {
-        this.activated = activated;
-    }
 }

--- a/src/main/java/com/grepp/funfun/app/domain/faq/service/FaqService.java
+++ b/src/main/java/com/grepp/funfun/app/domain/faq/service/FaqService.java
@@ -41,6 +41,7 @@ public class FaqService {
         Faq faq = new Faq();
         faq.setTitle(request.getTitle());
         faq.setContent(request.getContent());
+        faq.setActivated(true);
         return faqRepository.save(faq).getId();
     }
 

--- a/src/main/java/com/grepp/funfun/app/domain/faq/service/FaqService.java
+++ b/src/main/java/com/grepp/funfun/app/domain/faq/service/FaqService.java
@@ -10,6 +10,7 @@ import com.grepp.funfun.app.infra.error.exceptions.CommonException;
 import com.grepp.funfun.app.infra.response.ResponseCode;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -41,7 +42,6 @@ public class FaqService {
         Faq faq = new Faq();
         faq.setTitle(request.getTitle());
         faq.setContent(request.getContent());
-        faq.setActivated(true);
         return faqRepository.save(faq).getId();
     }
 


### PR DESCRIPTION
## 📌 과제 설명 
admin group api에서 group목록을 받아오는 데에서 이슈가 있었습니다. 
participantcount 를 할때 participant 를 일일히 불러와서 count 하는 부분을
now people로 대체하여 문제를 해결했습니다. 
contact 에서 answer을 입력할때 255자 제한이 있는 부분을 수정했습니다.

## 👩‍💻 요구 사항과 구현 내용 
- 불필요한 leaderNickname 을 삭제했습니다.
- getParticipants().size()) -> getNowPeople()로 해결했습니다.
- faq 관련 swagger operation 추가했습니다.
- contact에서 answer의 길이가 길어지면 post 가 되지않는 문제를 해결하기 위해  @Column(columnDefinition = "TEXT") 를 추가했습니다. 