### PR TITLE
fix: content 정렬 및 테스트 코드 수정

### DIFF
--- a/src/main/java/com/grepp/funfun/app/domain/content/controller/ContentApiController.java
+++ b/src/main/java/com/grepp/funfun/app/domain/content/controller/ContentApiController.java
@@ -5,7 +5,6 @@ import com.grepp.funfun.app.domain.content.dto.ContentListDTO;
 import com.grepp.funfun.app.domain.content.dto.ContentSimpleDTO;
 import com.grepp.funfun.app.domain.content.dto.payload.ContentDetailResponse;
 import com.grepp.funfun.app.domain.content.dto.payload.ContentFilterRequest;
-import com.grepp.funfun.app.domain.content.dto.ContentDTO;
 import com.grepp.funfun.app.domain.content.service.ContentService;
 import com.grepp.funfun.app.infra.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,10 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -41,16 +37,6 @@ public class ContentApiController {
     public ResponseEntity<ApiResponse<Page<ContentListDTO>>> getAllContents(
             @Valid @ParameterObject ContentFilterRequest request,
             @ParameterObject Pageable pageable) {
-        if (request.isBookmarkSort()) {
-            pageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
-                    Sort.by(Sort.Direction.DESC, "bookmarkCount"));
-        } else if (request.isEndDateSort()) {
-            pageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
-                    Sort.by(Sort.Direction.ASC, "endDate"));
-        } else {
-            pageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
-                    Sort.by(Sort.Direction.ASC, "distance"));
-        }
 
         Page<ContentListDTO> contents = contentService.findByFiltersWithSort(request, pageable);
         return ResponseEntity.ok(ApiResponse.success(contents));

--- a/src/main/java/com/grepp/funfun/app/domain/content/dto/ContentListDTO.java
+++ b/src/main/java/com/grepp/funfun/app/domain/content/dto/ContentListDTO.java
@@ -17,7 +17,7 @@ public class ContentListDTO {
 
     private String contentTitle;
 
-    private String fee;
+    private String address;
 
     private LocalDate startDate;
 

--- a/src/main/java/com/grepp/funfun/app/domain/content/service/ContentService.java
+++ b/src/main/java/com/grepp/funfun/app/domain/content/service/ContentService.java
@@ -74,35 +74,27 @@ public class ContentService {
     // 북마크순 정렬
     private Page<Content> findByFiltersOrderByBookmark(ContentFilterRequest request, Pageable pageable) {
 
-        log.info("생성된 sortedPageable: {}", pageable.getSort());
-        log.info("북마크순 정렬을 위해 repository 호출");
+        Sort sort = Sort.by(Sort.Direction.DESC, "bookmarkCount");
+        Pageable sortedPageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
 
-        Page<Content> result = contentRepository.findFilteredContents(
+        log.info("생성된 정렬: {}", sortedPageable.getSort());
+        
+        return contentRepository.findFilteredContents(
                 request.getCategory(),
                 request.getGuname(),
                 request.getStartDate(),
                 request.getEndDate(),
                 request.getKeyword(),
                 false,
-                pageable
+                sortedPageable
         );
-
-        log.info("repository에서 반환된 결과 개수: {}", result.getContent().size());
-        if (!result.getContent().isEmpty()) {
-            Content first = result.getContent().get(0);
-            log.info("첫 번째 결과 - ID: {}, bookmarkCount: {}", first.getId(), first.getBookmarkCount());
-            if (result.getContent().size() > 1) {
-                Content second = result.getContent().get(1);
-                log.info("두 번째 결과 - ID: {}, bookmarkCount: {}", second.getId(), second.getBookmarkCount());
-            }
-        }
-
-        return result;
     }
 
     // 마감 임박순 정렬
     private Page<Content> findByFiltersOrderByEndDate(ContentFilterRequest request, Pageable pageable) {
 
+        Sort sort = Sort.by(Sort.Direction.ASC, "endDate");
+        Pageable sortedPageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
 
         return contentRepository.findFilteredContents(
                 request.getCategory(),
@@ -111,7 +103,7 @@ public class ContentService {
                 request.getEndDate(),
                 request.getKeyword(),
                 false,
-                pageable
+                sortedPageable
         );
     }
 
@@ -217,9 +209,11 @@ public class ContentService {
                 .toList();
     }
 
-    private ContentSimpleDTO toSimpleDTO(Content content) { return modelMapper.map(content, ContentSimpleDTO.class); }
+    private ContentSimpleDTO toSimpleDTO(Content content) {
+        return modelMapper.map(content, ContentSimpleDTO.class); }
 
-    private ContentListDTO toContentListDTO(Content content) { return modelMapper.map(content, ContentListDTO.class); }
+    private ContentListDTO toContentListDTO(Content content) {
+        return modelMapper.map(content, ContentListDTO.class); }
 
     private ContentDetailDTO toDetailDTO(Content content) {
         return modelMapper.map(content, ContentDetailDTO.class);

--- a/src/main/java/com/grepp/funfun/app/domain/content/service/ContentService.java
+++ b/src/main/java/com/grepp/funfun/app/domain/content/service/ContentService.java
@@ -121,6 +121,10 @@ public class ContentService {
             String currentUserEmail = SecurityContextHolder.getContext()
                     .getAuthentication().getName();
 
+            if (currentUserEmail.equals("anonymousUser")){
+                return new Double[]{null, null};
+            }
+
             UserDTO user = userService.get(currentUserEmail);
             if (user != null && user.getLatitude() != null && user.getLongitude() != null) {
                 log.info("사용자 기본 위치 조회 : 위도={}, 경도={}",


### PR DESCRIPTION
## 📌 과제 설명 

## 👩‍💻 요구 사항과 구현 내용 
- contentService 테스트 코드 수정(modelmapper 및 DTO 추가로 인한 에러)
- 비로그인일 때 사용자의 위치 조회 방지
- 정렬이 잘 안 넘어간 문제
    - Pageable에 안 담고 넘겨줘서 그랬음
        
        → 새로운 Pageable에 정렬 포함하여 넘김
