### PR TITLE
refactor: admin report source type 별 분기 처리

### DIFF
--- a/src/main/java/com/grepp/funfun/app/domain/admin/controller/AdminReportApiController.java
+++ b/src/main/java/com/grepp/funfun/app/domain/admin/controller/AdminReportApiController.java
@@ -3,6 +3,7 @@ package com.grepp.funfun.app.domain.admin.controller;
 import com.grepp.funfun.app.domain.admin.dto.AdminReportViewDTO;
 import com.grepp.funfun.app.domain.admin.dto.payload.AdminReportProcessRequest;
 import com.grepp.funfun.app.domain.admin.service.AdminReportService;
+import com.grepp.funfun.app.domain.admin.vo.ReportSourceType;
 import com.grepp.funfun.app.infra.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -27,12 +28,13 @@ public class AdminReportApiController {
     }
 
     @PatchMapping("/{id}")
-    @Operation(summary = "신고 처리", description = "신고에 대한 유저 제재 or 답변 등록 처리")
+    @Operation(summary = "신고 처리", description = "신고에 대한 유저 제재 or 답변 등록 처리 -> sourceType: BUTTON_REPORT , CONTACT_REPORT")
     public ResponseEntity<ApiResponse<String>> processReport(
             @PathVariable Long id,
+            @RequestParam ReportSourceType sourceType,
             @RequestBody AdminReportProcessRequest request
             ){
-            adminReportService.processReport(id, request);
+            adminReportService.processReport(id, sourceType, request);
             return ResponseEntity.ok(ApiResponse.success("신고가 정상적으로 처리되었습니다."));
     }
 }

--- a/src/main/java/com/grepp/funfun/app/domain/admin/service/AdminReportService.java
+++ b/src/main/java/com/grepp/funfun/app/domain/admin/service/AdminReportService.java
@@ -84,10 +84,11 @@ public class AdminReportService {
     }
 
     @Transactional
-    public void processReport(Long id, AdminReportProcessRequest request) {
-        Optional<Report> optionalReport = reportRepository.findById(id);
-        if (optionalReport.isPresent()) {
-            Report report = optionalReport.get();
+    public void processReport(Long id, ReportSourceType sourceType, AdminReportProcessRequest request) {
+        switch (sourceType) {
+
+            case BUTTON_REPORT -> {
+                Report report = reportRepository.findById(id).orElseThrow(()-> new CommonException(ResponseCode.NOT_FOUND, "버튼형 신고("+id+")를 찾을 수 없습니다."));
 
             if (report.isResolved()) {
                 throw new CommonException(ResponseCode.BAD_REQUEST, "이미 처리 완료된 신고입니다.");
@@ -102,9 +103,8 @@ public class AdminReportService {
             }
 
             report.resolve(request.getAdminComment());
-            return;
         }
-
+        case CONTACT_REPORT -> {
         Contact contact = contactRepository.findById(id)
                 .orElseThrow(() -> new CommonException(ResponseCode.NOT_FOUND, "신고(ID=" + id + ")를 찾을 수 없습니다."));
 
@@ -117,5 +117,8 @@ public class AdminReportService {
         }
 
         contact.registAnswer(request.getAdminComment());
+    }
+            default -> throw new CommonException(ResponseCode.BAD_REQUEST, "알 수 없는 신고 유형입니다.");
+        }
     }
 }


### PR DESCRIPTION
## 📌 과제 설명
admin report 에서 source type 별 분기 처리 로직으로 수정했습니다.

## 👩‍💻 요구 사항과 구현 내용
신고 목록을 처리할 때에 source type 별로 나누어 switch-case로 나누어 해결했습니다.

## ✅ 피드백 반영사항 
기존 report를 가져올 때 경우의 수가 2가지였습니다. 문의형신고, 버튼형 신고인데 여기서 문의형은 contact 테이블로, 버튼형은 report테이블로 저장되기 때문에 id 만 조회해서 가져온 뒤 처리로직을 타게 될 경우 각 테이블의 동일한 아이디 데이터를 잘못 처리할수도 있기때문에 분기 처리가 필요하다고 말씀해주셔서 반영했습니다.