### PR TITLE
refactor: 모임 신청 알림 내 신청자 이메일 포함 관련 수정

### DIFF
--- a/src/main/java/com/grepp/funfun/app/domain/notification/dto/GroupJoinNotificationDTO.java
+++ b/src/main/java/com/grepp/funfun/app/domain/notification/dto/GroupJoinNotificationDTO.java
@@ -1,0 +1,29 @@
+package com.grepp.funfun.app.domain.notification.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class GroupJoinNotificationDTO extends NotificationDTO {
+
+    private final String applicantEmail;
+
+    @Builder(builderMethodName = "groupJoinBuilder")
+    public GroupJoinNotificationDTO(
+            Long id,
+            String email,
+            String message,
+            String link,
+            Boolean isRead,
+            String type,
+            LocalDateTime scheduledAt,
+            LocalDateTime sentAt,
+            Long calendarId,
+            String applicantEmail
+    ) {
+        super(id, email, message, link, isRead, type, scheduledAt, sentAt, calendarId);
+        this.applicantEmail = applicantEmail;
+    }
+}

--- a/src/main/java/com/grepp/funfun/app/domain/notification/dto/NotificationDTO.java
+++ b/src/main/java/com/grepp/funfun/app/domain/notification/dto/NotificationDTO.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,6 +12,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @Builder
+@AllArgsConstructor
 public class NotificationDTO {
 
     private final Long id;
@@ -37,6 +39,25 @@ public class NotificationDTO {
     @Schema(description = "일정 ID(해당 알림이 어떤 캘린더 일정과 연관되는지 확인용)")
     private final Long calendarId;
 
-    @Schema(description = "모임 신첟자의 이메일 (필요시에만 사용할 예정)")
-    private final String applicantEmail;
+    public NotificationDTO(
+            Long id,
+            String email,
+            String message,
+            String link,
+            Boolean isRead,
+            String type,
+            LocalDateTime scheduledAt,
+            LocalDateTime sentAt,
+            Long calendarId
+    ) {
+        this.id = id;
+        this.email = email;
+        this.message = message;
+        this.link = link;
+        this.isRead = isRead;
+        this.type = type;
+        this.scheduledAt = scheduledAt;
+        this.sentAt = sentAt;
+        this.calendarId = calendarId;
+    }
 }

--- a/src/main/java/com/grepp/funfun/app/domain/notification/dto/NotificationDTO.java
+++ b/src/main/java/com/grepp/funfun/app/domain/notification/dto/NotificationDTO.java
@@ -12,7 +12,6 @@ import java.time.LocalDateTime;
 
 @Getter
 @Builder
-@AllArgsConstructor
 public class NotificationDTO {
 
     private final Long id;

--- a/src/main/java/com/grepp/funfun/app/domain/notification/entity/Notification.java
+++ b/src/main/java/com/grepp/funfun/app/domain/notification/entity/Notification.java
@@ -19,6 +19,7 @@ public class Notification extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     private String email;
 
     private String message;
@@ -39,4 +40,8 @@ public class Notification extends BaseEntity {
     private LocalDateTime sentAt;
 
     private Long calendarId;
+
+    @Column(name = "applicant_email")
+    private String applicantEmail;
+
 }

--- a/src/main/java/com/grepp/funfun/app/domain/notification/mapper/NotificationDTOMapper.java
+++ b/src/main/java/com/grepp/funfun/app/domain/notification/mapper/NotificationDTOMapper.java
@@ -1,5 +1,6 @@
 package com.grepp.funfun.app.domain.notification.mapper;
 
+import com.grepp.funfun.app.domain.notification.dto.GroupJoinNotificationDTO;
 import com.grepp.funfun.app.domain.notification.dto.NotificationDTO;
 import com.grepp.funfun.app.domain.notification.entity.Notification;
 import com.grepp.funfun.app.domain.notification.vo.NotificationType;
@@ -32,7 +33,9 @@ public class NotificationDTOMapper {
                 .scheduledAt(dto.getScheduledAt())
                 .sentAt(dto.getSentAt())
                 .calendarId(dto.getCalendarId())
+                .applicantEmail(dto instanceof GroupJoinNotificationDTO
+                        ? ((GroupJoinNotificationDTO) dto).getApplicantEmail()
+                        : null)
                 .build();
     }
-
 }

--- a/src/main/java/com/grepp/funfun/app/domain/notification/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/grepp/funfun/app/domain/notification/scheduler/NotificationScheduler.java
@@ -42,7 +42,7 @@ public class NotificationScheduler {
             NotificationDTO dto = NotificationDTO.builder()
                     .email(calendar.getEmail())
                     .message(message)
-                    .link("/calendar") //fe에서의 라우터에 따라 변경
+                    .link("/user/calendar") //fe에서의 라우터에 따라 변경
                     .isRead(false)
                     .type(NotificationType.SCHEDULE.name())
                     .scheduledAt(LocalDateTime.now())

--- a/src/main/java/com/grepp/funfun/app/domain/participant/service/ParticipantService.java
+++ b/src/main/java/com/grepp/funfun/app/domain/participant/service/ParticipantService.java
@@ -5,6 +5,7 @@ import com.grepp.funfun.app.domain.group.entity.Group;
 import com.grepp.funfun.app.domain.group.repository.GroupRepository;
 import com.grepp.funfun.app.domain.group.vo.GroupClassification;
 import com.grepp.funfun.app.domain.group.vo.GroupStatus;
+import com.grepp.funfun.app.domain.notification.dto.GroupJoinNotificationDTO;
 import com.grepp.funfun.app.domain.notification.dto.NotificationDTO;
 import com.grepp.funfun.app.domain.notification.service.NotificationService;
 import com.grepp.funfun.app.domain.participant.dto.payload.GroupCompletedStatsResponse;
@@ -100,14 +101,14 @@ public class ParticipantService {
         participantRepository.save(participant);
 
         // 모임 신청오면 주최자에게 알림전송
-        notificationService.create(NotificationDTO.builder()
+        notificationService.create(GroupJoinNotificationDTO.groupJoinBuilder()
                 .email(group.getLeader().getEmail())
                 .message(user.getNickname() + "님이 '" + group.getTitle() + "' 모임에 가입을 신청했습니다.")
                 .link("/groups/" + group.getId())
                 .type("NOTICE")
                 .isRead(false)
                 .sentAt(LocalDateTime.now())
-                        .applicantEmail(user.getEmail())
+                .applicantEmail(user.getEmail())
                 .build());
 
     }


### PR DESCRIPTION
## 📌 과제 설명 
모임 신청시 주최자에게 전송되는 알림에 신청자 이메일(applicantEmail) 을 포함하여 프론트엔드 측에 보내는 중에 null 로 전달되는 것을 확인하고 수정했습니다.

## 👩‍💻 요구 사항과 구현 내용
- GroupJoinNotificationDTO 클래스 생성 -> NotificationDTO 확장하여 신청자 이메일 필드를 추가하는 방식으로 수정했습니다.
- 이에 따라 NotificationDTOMapper 에서 GroupJoinNotificationDTO 관련 내용을 수정했습니다.
- Notification 엔티티 또한 필드 추가했습니다.
- applicantEmail은 선택적 필드로, 다른 알림 로직에는 영향을 주지 않도록 조건 처리했습니다.